### PR TITLE
docs: expand zensical site coverage

### DIFF
--- a/docs/collectors/arp-ndp.md
+++ b/docs/collectors/arp-ndp.md
@@ -1,0 +1,79 @@
+# ARP and IPv6 Neighbor Discovery
+
+The `arp` and `ndp` collectors share the same logic
+(`NapalmCollector._ip_neighbors`); they differ only in the NAPALM call
+used and the IP family they consider.
+
+## NAPALM calls
+
+| Collector | Call |
+|---|---|
+| `arp` | `driver.get_arp_table()` |
+| `ndp` | `driver.get_ipv6_neighbors_table()` |
+
+The bundled `EnhancedJunOSDriver` overrides both calls to produce
+generators directly from PyEZ tables, normalizing MAC and IP formats.
+
+## What it produces per entry
+
+Two `FactsReportEntry` rows per detected neighbor:
+
+1. A MAC entry with `object_repr = "MACAddress <mac>"`.
+2. An IP entry with `object_repr` pointing to the matched
+   `IPAddress` (or the literal CIDR for new entries).
+
+Both entries share the same `detected_values`:
+
+```json
+{
+  "mac": "aa:bb:cc:11:22:33",
+  "ip": "10.0.0.5/24",
+  "interface": "ge-0/0/0.0",
+  "vrf": "VRF_A"
+}
+```
+
+## Action selection
+
+- MAC: `confirmed` if a `MACAddress` already exists, otherwise `new`.
+- IP: `confirmed` if an `IPAddress` exists in the matching VRF,
+  otherwise `new`.
+- Stale IPs: previously auto-discovered IPs (`AUTO_D_TAG` tag) on this
+  device, in the matching family (`v4` for ARP, `v6` for NDP), that were
+  not seen this run are flagged with action `stale`.
+
+## VRF resolution
+
+For each interface, the collector reads `get_network_instances()` and
+matches the interface to a VRF via
+`resolve_napalm_network_instances()`. Unknown VRFs are logged as a
+warning and the IP is skipped.
+
+## Apply behavior
+
+Apply mode (or applying a pending entry):
+
+- Get-or-create the `MACAddress`. New rows get the **Automatically
+  Discovered** tag.
+- Add the device's local interface to `MACAddress.interfaces`.
+- Get-or-create the `IPAddress` in the resolved VRF. Newly-created IPs
+  also get the auto-discovery tag and a `JournalEntry` recording the
+  device, MAC, and interface.
+- Add the IP to `MACAddress.ip_addresses` and update `last_seen`.
+
+Stale IPs are unassigned (`assigned_object = None`) when applied.
+
+## Performance
+
+Both bulk-prefetch existing MACs and IPs once per device to avoid N+1
+lookups. Annotation `HOST(address)` is used to match raw IP strings
+against `IPAddress.address` regardless of mask.
+
+## Edge cases handled
+
+- Empty MAC strings, MACs with state `unreachable`, and incomplete entries
+  are skipped.
+- Interfaces present in the ARP/NDP table but not in NetBox are logged
+  (collapsed to a count when there are more than five).
+- Duplicate MACs / IPs in NetBox surface as a warning and the entry is
+  skipped (manual cleanup is expected).

--- a/docs/collectors/bgp.md
+++ b/docs/collectors/bgp.md
@@ -1,0 +1,87 @@
+# BGP
+
+The `bgp` collector ingests BGP neighbor data and, when the
+[netbox-routing](https://github.com/netbox-community/netbox-routing) plugin
+is installed, populates `BGPRouter`, `BGPScope`, and `BGPPeer` rows in
+addition to creating the peer IP and ASN.
+
+## NAPALM call
+
+- `driver.get_bgp_neighbors_detail()`. Returns a nested dict keyed by VRF
+  name, then by remote AS.
+
+## What it produces
+
+For every peer in every VRF, a peer-IP entry:
+
+```json
+{
+  "remote_address": "10.0.0.2",
+  "remote_as": 65002,
+  "vrf": "VRF_A",
+  "state": "up"
+}
+```
+
+`remote_address` is normalized to a `/32` (IPv4) or `/128` (IPv6) before
+being matched against NetBox.
+
+Action: `confirmed` if an `IPAddress` exists at that CIDR in the resolved
+VRF, else `new`.
+
+A separate entry is emitted for every unknown VRF
+(`object_repr = "VRF <name>"`, action `new`). Apply creates the VRF.
+
+## Apply behavior
+
+- Get-or-create an `ASN` for the remote AS. Requires that at least one
+  `RIR` exists in NetBox; if none exists, the ASN creation is skipped
+  with a warning.
+- Get-or-create the `IPAddress` in the resolved VRF, tagged
+  auto-discovered.
+- Record a `JournalEntry` summarizing the peer when the IP is new.
+
+## netbox-routing integration
+
+If `netbox_routing` can be imported, after processing all peers the
+collector additionally records:
+
+- `BGPRouter` (`object_repr = "BGPRouter <device>"`) keyed by
+  `(device, local_asn)`.
+- One `BGPScope` per VRF (`object_repr = "BGPScope <device> <vrf|global>"`)
+  keyed by `(router, vrf)`.
+- One `BGPPeer` per peer (`object_repr = "BGPPeer <ip> AS<asn>"`) keyed by
+  `(scope, peer_ip)`.
+
+In detect-only mode these entries reflect what would be created. In apply
+mode the rows are written immediately, all tagged
+**Automatically Discovered**.
+
+The dedicated apply handlers
+(`_apply_bgp_router_entry`, `_apply_bgp_scope_entry`,
+`_apply_bgp_peer_routing_entry`) re-run the same `get_or_create` chain,
+so a pending detect-only entry can be applied later just like the inline
+path.
+
+## Without netbox-routing
+
+The collector still produces peer-IP entries and creates the
+`IPAddress` / `ASN` rows. The routing integration block is skipped with a
+single info-level log.
+
+To enable the integration:
+
+```bash
+pip install "netbox-facts[routing]"
+```
+
+then add `netbox_routing` to `PLUGINS` and migrate.
+
+## Skip conditions
+
+- Empty `remote_address`.
+- Unparseable IP (logged as a warning, peer skipped).
+- Unknown VRF (the missing-VRF entry is recorded; peers in that VRF are
+  skipped this run).
+- Duplicate `IPAddress` or `ASN` rows (logged, skipped, manual cleanup
+  expected).

--- a/docs/collectors/ethernet-switching.md
+++ b/docs/collectors/ethernet-switching.md
@@ -1,0 +1,39 @@
+# Ethernet Switching Tables
+
+The `ethernet_switching` collector ingests learned MACs from a switch's
+forwarding table.
+
+## NAPALM call
+
+- `driver.get_mac_address_table()`.
+
+## What it produces
+
+For each MAC table entry:
+
+```json
+{
+  "mac": "aa:bb:cc:11:22:33",
+  "interface": "ge-0/0/12",
+  "vlan": 100
+}
+```
+
+Action: `confirmed` if a `MACAddress` already exists, else `new`.
+
+`object_repr` is
+`MACAddress <mac> on <interface markdown link>`.
+
+## Apply behavior
+
+- Get-or-create the `MACAddress` (tagged auto-discovered if new).
+- Add the local interface to `MACAddress.interfaces`.
+- Set `discovery_method = ethernet_switching` and refresh `last_seen`.
+
+## Skip conditions
+
+- MAC or interface name is empty.
+- The interface name does not match `valid_interfaces_re`.
+- The interface does not exist in NetBox (logged warning, skipped).
+- Duplicate `MACAddress` rows exist for the address (logged warning,
+  manual cleanup expected).

--- a/docs/collectors/evpn.md
+++ b/docs/collectors/evpn.md
@@ -1,0 +1,37 @@
+# EVPN
+
+The `evpn` collector dispatches to a vendor-specific implementation. Only
+`junos` is wired up today.
+
+## Junos collection
+
+- Runs `driver.cli(["show evpn mac-table"])`.
+- Scrapes MAC addresses out of the raw output via a single regex:
+  `([0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5})`.
+
+## What it produces
+
+Per MAC matched in the output:
+
+```json
+{"mac": "aa:bb:cc:11:22:33"}
+```
+
+Action: `confirmed` if a `MACAddress` already exists, else `new`.
+
+## Apply behavior
+
+- Get-or-create the `MACAddress`.
+- Set `discovery_method = evpn` and `last_seen = now`.
+
+A single `JournalEntry` is recorded on the device for the run, including
+the first 2000 characters of the raw `show evpn mac-table` output.
+
+## Limitations
+
+- The collector does not currently parse interface, VTEP, ESI, or
+  encapsulation context out of the EVPN output.
+- Only Junos is supported. Adding another vendor requires implementing
+  `_evpn_<vendor>(self, driver)` and registering the driver in the
+  `vendor_map` inside `_get_vendor_method()`. See
+  [Vendor Dispatch](../developer/vendor-dispatch.md).

--- a/docs/collectors/index.md
+++ b/docs/collectors/index.md
@@ -1,0 +1,65 @@
+# Collectors Overview
+
+Each `CollectionPlan` runs exactly one collector. The full set is defined
+in `CollectionTypeChoices` (`netbox_facts/choices.py`):
+
+| Type key | Display | NAPALM call(s) | Vendor-specific dispatch? |
+|---|---|---|---|
+| `arp` | ARP | `get_arp_table()` | No (Junos driver enriched) |
+| `ndp` | IPv6 Neighbor Discovery | `get_ipv6_neighbors_table()` | No (Junos driver enriched) |
+| `inventory` | Inventory | `get_facts()` + (Junos) `get_chassis_inventory()` | Junos has chassis path |
+| `interfaces` | Interfaces | `get_interfaces()` + `get_interfaces_ip()` + `get_network_instances()` | Enhanced Junos data unlocks the logical-interfaces path |
+| `lldp` | LLDP | `get_lldp_neighbors_detail()` | No |
+| `ethernet_switching` | Ethernet Switching Tables | `get_mac_address_table()` | No |
+| `l2_circuits` | L2 Circuits | CLI: `show l2circuit connections` | Yes (Junos only) |
+| `evpn` | EVPN | CLI: `show evpn mac-table` | Yes (Junos only) |
+| `bgp` | BGP | `get_bgp_neighbors_detail()` | No |
+| `ospf` | OSPF | CLI: `show ospf neighbor` | Yes (Junos only) |
+
+The runner is `NapalmCollector` in `netbox_facts/helpers/collector.py`.
+Each collector method matches the type key (e.g. `arp()`,
+`ethernet_switching()`).
+
+## Detect-only and apply
+
+Every collector follows the same pattern:
+
+1. Compare the device-reported value with NetBox state.
+2. Call `_record_entry()` to create a `FactsReportEntry` with one of
+   `new`, `changed`, `confirmed`, or `stale`.
+3. If `_should_apply()` returns `True` (i.e. `detect_only=False`),
+   perform the mutation and call `_mark_entry_applied()`.
+
+A second apply path (`netbox_facts/helpers/applier.py`) re-implements the
+same handlers in a per-entry-savepoint form so reviewers can selectively
+apply pending entries from a detect-only report. The dispatch table is
+`APPLY_HANDLERS`.
+
+## Auto-discovered tag
+
+Objects created by collectors are tagged
+**Automatically Discovered** (constant: `AUTO_D_TAG`). Stale detection
+relies on this tag, so manually-added objects are never considered stale.
+
+## Interface filter
+
+The plugin-wide `valid_interfaces_re` setting filters which interfaces a
+collector iterates. It is compiled once per run and applied to:
+
+- ARP / NDP entries grouped by interface.
+- Interface entries from `get_interfaces()`.
+- Ethernet switching MAC entries.
+
+Interfaces whose names do not match are silently skipped.
+
+## Per-collector pages
+
+- [ARP and NDP](arp-ndp.md)
+- [Inventory](inventory.md)
+- [Interfaces](interfaces.md)
+- [LLDP](lldp.md)
+- [Ethernet Switching](ethernet-switching.md)
+- [EVPN](evpn.md)
+- [L2 Circuits](l2-circuits.md)
+- [BGP](bgp.md)
+- [OSPF](ospf.md)

--- a/docs/collectors/interfaces.md
+++ b/docs/collectors/interfaces.md
@@ -1,0 +1,93 @@
+# Interfaces
+
+The `interfaces` collector reconciles physical and logical interface state,
+LAG membership, IP addresses, prefixes, and (where applicable) VRF
+assignment.
+
+## NAPALM calls
+
+- `driver.get_interfaces()` for physical / logical port data and
+  attributes.
+- `driver.get_interfaces_ip()` for IP-per-interface data on drivers that
+  do not return logical-interface data inline.
+- `driver.get_network_instances()` for VRF resolution.
+
+The bundled `EnhancedJunOSDriver.get_interfaces()` returns a
+`logical_interfaces` sub-dict, which lets the collector go through a
+richer code path that also captures LAG (`aenet`) membership and per-LU
+VRF binding.
+
+## Auto-create behavior
+
+Interfaces seen on the device but missing in NetBox are auto-created with:
+
+- type inferred by `detect_interface_type()`:
+    - `lag` for `ae*` (no dot)
+    - `virtual` for names containing a dot (logical units), or starting
+      with `lo`, `irb`, `vlan`
+    - `other` otherwise
+- `description`, `enabled`, `mtu` populated from NAPALM data when
+  available
+- parent set to the physical interface for sub-interfaces
+- the **Automatically Discovered** tag
+
+## What it produces
+
+For each physical interface with a MAC:
+
+```json
+{
+  "interface": "ge-0/0/0",
+  "mac_address": "aa:bb:cc:11:22:33",
+  "is_enabled": true,
+  "speed": 1000,
+  "mtu": 9000,
+  "is_up": true
+}
+```
+
+Action: `confirmed` if a matching `MACAddress` exists, else `new`. Apply
+links the MAC to the interface as `device_interface` (one-to-one) and
+sets `discovery_method = interfaces`.
+
+For LAG members (Junos `aenet` family):
+
+```json
+{"interface": "ge-0/0/0.0", "lag_parent": "ae0"}
+```
+
+Action: `confirmed` / `changed` / `new` based on the current `lag` FK.
+Apply auto-creates the `aeN` interface if necessary and sets `lag`.
+
+For each IP discovered on a logical interface:
+
+```json
+{
+  "logical_interface": "ge-0/0/0.0",
+  "ip_address": "10.0.0.1/30",
+  "vrf": "VRF_A",
+  "prefix": "10.0.0.0/30"
+}
+```
+
+Action: `new`, `changed` (the IP is reassigning to a different interface
+and is auto-discovered), or `confirmed`. Apply creates the `Prefix` (for
+non-host routes) and the `IPAddress`, both tagged auto-discovered.
+
+For each VRF the collector cannot find in NetBox, an entry is recorded
+with `object_repr = "VRF <name>"` and action `new`. Apply creates the
+VRF row.
+
+## Stale IP detection
+
+After processing, `_detect_stale_ips()` finds every `IPAddress` assigned
+to one of the device's virtual-chassis interfaces and tagged
+auto-discovered, then flags any that were not visited this run as
+`stale`. Apply unassigns the IP (sets `assigned_object = None`).
+
+## VRP / generic fallback
+
+Drivers without enhanced logical-interface data (most non-Junos drivers)
+go through `_interfaces_ip_generic()`, which walks
+`get_interfaces_ip()` directly and pulls VRFs from the resolved network
+instances. The same entry/apply shape is used.

--- a/docs/collectors/inventory.md
+++ b/docs/collectors/inventory.md
@@ -1,0 +1,98 @@
+# Inventory
+
+The `inventory` collector keeps device-level facts and (on Junos) chassis
+hardware in sync with NetBox.
+
+## NAPALM calls
+
+- `driver.get_facts()` for serial / OS version / hostname / fqdn.
+- `driver.get_chassis_inventory()` if available (the bundled enhanced
+  Junos driver provides one). Used to reconcile `dcim.InventoryItem` and
+  `dcim.Module` rows.
+
+## Device-level entry
+
+For every device, the collector emits a single entry whose
+`object_repr` is the device markdown link.
+
+`detected_values`:
+
+```json
+{
+  "serial_number": "JN12345678AB",
+  "os_version": "21.4R3.10",
+  "hostname": "core-01",
+  "fqdn": "core-01.example.com"
+}
+```
+
+`current_values`: `{"serial_number": "<existing>"}`.
+
+Action:
+
+- `changed` if the serial differs from `Device.serial`.
+- `confirmed` otherwise.
+
+Apply behavior writes the new serial to `Device.serial` and records a
+`JournalEntry` summarizing OS version, hostname, and FQDN.
+
+## Chassis inventory (Junos)
+
+When `driver.get_chassis_inventory()` exists, the collector also walks
+hardware modules.
+
+For each chassis module:
+
+- Skip `BUILTIN` modules and Routing Engines (the latter are covered by
+  `get_facts`).
+- Compare to the existing `InventoryItem` for the device by name. Action
+  is `new`, `changed` (serial / part_id / description differ), or
+  `confirmed`.
+- If a matching `dcim.ModuleBay` and `dcim.ModuleType` exist for the
+  device's manufacturer (matched on `part_number`, then `model`), an
+  additional Module entry is emitted with `object_repr = "Module <bay>"`.
+
+`detected_values` for an inventory item:
+
+```json
+{
+  "name": "FPC 0",
+  "parent_name": null,
+  "serial": "AB1234567",
+  "part_id": "MX-MPC2E-3D",
+  "description": "Modular Port Concentrator"
+}
+```
+
+For a chassis module:
+
+```json
+{
+  "name": "FPC 0/PIC 0",
+  "component_name": "PIC 0",
+  "parent_name": "FPC 0",
+  "serial": "BB9876543",
+  "part_id": "MIC-3D-4XGE-XFP",
+  "description": "...",
+  "module_bay_id": 42,
+  "module_type_id": 7
+}
+```
+
+## Stale detection
+
+- `InventoryItem` rows on this device with `discovered=True` whose names
+  were not seen this run are flagged `stale`. Apply deletes them.
+- `Module` rows on this device tagged **Automatically Discovered** whose
+  bays were not visited are flagged `stale`. Apply deletes them.
+
+## Apply specifics
+
+- Newly created `InventoryItem` rows are saved with `discovered=True` and
+  tagged auto-discovered.
+- Module creation goes through `create_module()` which sets
+  `_adopt_components=True` and `_disable_replication=True` so existing
+  child components are adopted instead of being duplicated.
+- Parent / child relationships are resolved within the same run by
+  remembering newly-created items in `created_items` and modules in
+  `modules_by_name`.

--- a/docs/collectors/l2-circuits.md
+++ b/docs/collectors/l2-circuits.md
@@ -1,0 +1,39 @@
+# L2 Circuits
+
+The `l2_circuits` collector dispatches to a vendor-specific implementation.
+Only `junos` is wired up today.
+
+## Junos collection
+
+- Runs `driver.cli(["show l2circuit connections"])`.
+- The truncated raw output (first 2000 characters) is captured verbatim.
+
+## What it produces
+
+A single `FactsReportEntry` per device:
+
+```json
+{"raw_output": "..."}
+```
+
+Action: `confirmed` (the collector does not currently parse circuit
+state, so it simply records that data was collected).
+
+## Apply behavior
+
+Apply creates a `JournalEntry` on the device whose body is a fenced code
+block containing the raw output:
+
+````markdown
+L2 circuit data collected:
+```
+<truncated output>
+```
+````
+
+## Limitations
+
+- No structured circuit objects are created (NetBox core does not yet
+  ship a generic L2 circuit model that this plugin can target).
+- Only Junos is supported. See
+  [Vendor Dispatch](../developer/vendor-dispatch.md) for adding a vendor.

--- a/docs/collectors/lldp.md
+++ b/docs/collectors/lldp.md
@@ -1,0 +1,70 @@
+# LLDP
+
+The `lldp` collector inspects LLDP neighbors and creates `dcim.Cable`
+rows between matching local and remote interfaces.
+
+## NAPALM call
+
+- `driver.get_lldp_neighbors_detail()`.
+
+## Same-site rule
+
+The collector deliberately restricts cable creation to neighbors in the
+**same site** as the local device:
+
+```python
+if remote_device.site_id != device.site_id:
+    self._log_info(...)
+    continue
+```
+
+This prevents a misidentified hostname from creating an erroneous
+intra-DC cable across sites. If you need cross-site cabling, the cables
+must be added manually.
+
+## Remote device resolution
+
+`resolve_device_by_name()` matches the remote device by name with
+progressive domain stripping: `switch.dc1.example.com` ->
+`switch.dc1.example` -> `switch.dc1` -> `switch`, until a unique match is
+found. `MultipleObjectsReturned` propagates and triggers a warning;
+`DoesNotExist` results in a skipped neighbor.
+
+## What it produces
+
+Per matched neighbor:
+
+```json
+{
+  "local_interface": "ge-0/0/0",
+  "remote_device": "switch2.example.com",
+  "remote_interface": "ge-0/0/4",
+  "remote_chassis_id": "aa:bb:cc:11:22:33"
+}
+```
+
+Action: always `new` (the collector only emits an entry when both
+interfaces exist and neither is already cabled).
+
+## Apply behavior
+
+- Construct a `Cable` between `local_iface` and `remote_iface` with
+  status `connected`.
+- Validate, save, tag with **Automatically Discovered**.
+- Record a `JournalEntry` on the local device summarizing the link.
+
+The corresponding apply handler in
+`netbox_facts/helpers/applier.py::_apply_lldp_entry` re-runs the same
+checks in case the topology changed between detection and apply (one of
+the interfaces having gained a cable in the interim raises
+`ValueError("Interface already has a cable")`, marking the entry as
+failed).
+
+## Skip conditions
+
+The collector silently skips a neighbor when any of the following hold:
+
+- `remote_system_name` or `remote_port` is empty.
+- The remote device cannot be resolved or is in a different site.
+- The remote interface does not exist in NetBox.
+- Either interface already has a cable.

--- a/docs/collectors/ospf.md
+++ b/docs/collectors/ospf.md
@@ -1,0 +1,46 @@
+# OSPF
+
+The `ospf` collector dispatches to a vendor-specific implementation. Only
+`junos` is wired up today.
+
+## Junos collection
+
+- Runs `driver.cli(["show ospf neighbor"])`.
+- Parses each line with the regex
+  `^(\d+\.\d+\.\d+\.\d+)\s+(\S+)\s+(\S+)\s+(\d+\.\d+\.\d+\.\d+)`,
+  yielding `(neighbor_ip, interface, state, router_id)`.
+
+## What it produces
+
+Per neighbor:
+
+```json
+{
+  "address": "10.0.0.1",
+  "interface": "ge-0/0/0.0",
+  "state": "Full",
+  "router_id": "10.255.0.1"
+}
+```
+
+Action: `confirmed` if an `IPAddress` already exists at `<address>/32`,
+else `new`.
+
+`object_repr` is
+`OSPF neighbor <ip|markdown link> (RID: <router_id>)`.
+
+## Apply behavior
+
+- Get-or-create the `IPAddress` at `<address>/32` (auto-discovered tag).
+- Record a single `JournalEntry` per device summarizing all neighbors.
+- If `netbox_routing` is installed, look up the device's
+  `OSPFInstance` and log it (no row creation today).
+
+## Limitations
+
+- IPv4 only (the regex requires dotted-quad addresses).
+- No `OSPFNeighbor` row creation; the integration with `netbox-routing`
+  is currently informational. Extending it requires registering an
+  `OSPFNeighbor` model and adapting `_ospf_routing_integration()`.
+- Only Junos is supported. See
+  [Vendor Dispatch](../developer/vendor-dispatch.md) for adding a vendor.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,92 @@
+# Configuration
+
+All plugin-wide options live under `PLUGINS_CONFIG["netbox_facts"]` in your
+NetBox configuration. The defaults match what `FactsConfig.default_settings`
+declares in `netbox_facts/__init__.py`.
+
+## Settings reference
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `top_level_menu` | bool | `True` | Render the plugin as an **Operational Facts** top-level menu. When `False`, entries appear under **Plugins**. |
+| `napalm_username` | str | `""` | Default NAPALM username for device connections. Empty disables device login unless overridden per plan. |
+| `napalm_password` | str | `""` | Default NAPALM password. Empty disables device login unless overridden per plan. |
+| `napalm_timeout` | int | `60` | Connection timeout passed to the NAPALM driver as `optional_args["timeout"]` when the per-plan `napalm_args` does not already set it. |
+| `global_napalm_args` | dict | `{}` | Extra NAPALM `optional_args` merged into every plan. The plan's own `napalm_args` overrides matching keys. |
+| `valid_interfaces_re` | str | `".*"` | Regex applied to interface names by collectors that walk per-interface tables (ARP, NDP, interfaces, ethernet switching). Interfaces whose name does not match are skipped. |
+| `job_timeout` | int | `1800` | Maximum runtime in seconds passed to RQ when enqueuing a `CollectionJobRunner` job. |
+
+## Example
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_facts": {
+        "top_level_menu": True,
+        "napalm_username": "netbox-collector",
+        "napalm_password": "use-secrets-management-here",
+        "napalm_timeout": 90,
+        "global_napalm_args": {
+            "port": 22,
+            "keepalive": 30,
+        },
+        "valid_interfaces_re": r"^(ge|xe|et|ae|et|lo|irb|vlan)\S*$",
+        "job_timeout": 3600,
+    },
+}
+```
+
+## Per-plan credentials
+
+Each Collection Plan has a **NAPALM arguments** JSON field that is merged on
+top of `global_napalm_args`. To override the username and password for a
+specific plan, include `username` and `password` keys:
+
+```json
+{
+    "username": "collector-user",
+    "password": "collector-pass"
+}
+```
+
+These two keys are extracted by the collector before the remainder is
+passed to NAPALM as `optional_args`, so they will not interfere with driver
+options. See `NapalmCollector.__init__` in
+`netbox_facts/helpers/collector.py` for the resolution order.
+
+## Connection target
+
+Each plan also has a **Connection target** field (`connection_target`) that
+controls which device IP address the collector dials:
+
+| Value | Behavior |
+|---|---|
+| `primary` | Use `device.primary_ip` only. |
+| `oob` | Use `device.oob_ip` only. |
+| `primary_then_oob` | Try the primary IP first; on `ConnectionException`, fall back to OOB. |
+| `oob_then_primary` | Try the OOB IP first; on `ConnectionException`, fall back to the primary. |
+
+The "both" options are useful when devices are reachable via either path
+depending on network conditions. Each attempt logs the IP and the label
+(`primary` / `oob`) being used.
+
+## Permissions
+
+The plugin ships standard Django permissions for each model
+(`view_*`, `add_*`, `change_*`, `delete_*`) plus a custom permission used
+by the apply workflow:
+
+- `netbox_facts.apply_factsreport` -- required to apply or skip pending
+  entries on a `FactsReport`.
+
+Grant the permission via the standard NetBox permission system to the user
+or group that should be allowed to mutate NetBox from a detect-only run.
+
+## Job timeout vs NAPALM timeout
+
+These are independent:
+
+- `napalm_timeout` (default 60s) bounds a single NAPALM RPC call.
+- `job_timeout` (default 1800s / 30 min) bounds the entire RQ job that
+  iterates every device in a plan.
+
+If a plan covers many devices, `job_timeout` is the value to raise.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,82 @@
+# Installation
+
+## Requirements
+
+- NetBox 4.5.x
+- Python 3.12, 3.13, or 3.14
+- A reachable PostgreSQL database and Redis (the standard NetBox stack)
+- NAPALM-compatible network devices
+
+## Install from PyPI
+
+```bash
+pip install netbox-facts
+```
+
+To enable the optional [netbox-routing](https://github.com/netbox-community/netbox-routing)
+integration (required for the BGP collector to populate `BGPRouter`,
+`BGPScope`, and `BGPPeer`), install the `routing` extra:
+
+```bash
+pip install "netbox-facts[routing]"
+```
+
+## Install from source
+
+```bash
+pip install git+https://github.com/jsenecal/netbox-facts
+```
+
+Or pin via your `local_requirements.txt` / `plugin_requirements.txt`:
+
+```text
+git+https://github.com/jsenecal/netbox-facts
+```
+
+## Enable the plugin
+
+Edit `/opt/netbox/netbox/netbox/configuration.py` (or, for netbox-docker,
+`/configuration/plugins.py`) and add `netbox_facts` to `PLUGINS`:
+
+```python
+PLUGINS = [
+    "netbox_facts",
+]
+```
+
+A minimal `PLUGINS_CONFIG` block:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_facts": {
+        "top_level_menu": True,
+        "napalm_username": "",
+        "napalm_password": "",
+        "global_napalm_args": {},
+        "valid_interfaces_re": r".*",
+    },
+}
+```
+
+See [Configuration](configuration.md) for every available setting.
+
+## Run migrations
+
+```bash
+python manage.py migrate netbox_facts
+```
+
+Restart NetBox (and the RQ workers) so the plugin's `JobRunner` is
+registered.
+
+## Verify the install
+
+After restart, the navigation menu should show an **Operational Facts**
+top-level entry (or, if `top_level_menu` is `False`, entries under the
+**Plugins** menu). The REST API root at `/api/plugins/facts/` should list
+the four resources:
+
+- `macaddresses/`
+- `macvendors/`
+- `collectionplans/`
+- `factsreports/`

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,95 @@
+# Quick Start
+
+This walkthrough assumes you have already
+[installed and configured](installation.md) the plugin and have at least
+one NetBox device with a primary IP that you can reach via NAPALM.
+
+## 1. Create a Collection Plan
+
+Navigate to **Operational Facts -> Facts Collection -> Collection Plans**
+and click **Add**.
+
+Required fields:
+
+- **Name**: a human-readable label (e.g. `core-arp-junos`).
+- **Collector type**: pick one of the ten types (start with `Inventory` or
+  `LLDP` for low-risk verification).
+- **NAPALM driver**: e.g. `junos`, `ios`, `eos`, `nxos_ssh`.
+- **Devices** (or any of the scoping fields below).
+
+Useful fields:
+
+- **Detect-only**: tick this. It causes the run to produce a
+  `FactsReport` instead of mutating NetBox.
+- **NAPALM arguments**: JSON. Include `{"username": "...", "password": "..."}`
+  if this plan should not use the global credentials.
+- **Connection target**: leave on `Primary IP` unless you want OOB
+  fallback.
+- **Interval (minutes)**: leave blank for an on-demand plan, or set a
+  value to schedule recurring runs.
+
+## 2. Scope the plan to devices
+
+Plans select devices through any combination of the M2M fields below. Each
+populated field narrows the result (AND across dimensions, OR within):
+
+- `devices` (explicit list)
+- `regions`, `site_groups`, `sites`, `locations`
+- `device_types`, `roles`, `platforms`
+- `tenant_groups`, `tenants`
+- `tags`
+- `device_status` (one or more `DeviceStatusChoices` values; defaults to
+  `active` when none selected)
+
+The resolved queryset is built by `CollectionPlan.get_devices_queryset()`.
+
+## 3. Run the plan
+
+From the plan detail page, click **Run**. The plan transitions to
+`queued`, then `working`, and the resulting `Job` log shows the per-device
+NAPALM activity. When the job ends, the linked `FactsReport` is visible
+under **Operational Facts -> Facts Reports**.
+
+You can also enqueue a run via the API:
+
+```bash
+curl -X POST \
+  -H "Authorization: Token <token>" \
+  https://netbox.example.com/api/plugins/facts/collectionplans/<id>/run/
+```
+
+The response is `202 Accepted` with `{"job": <pk>}`.
+
+## 4. Review the report
+
+Open the report. The summary shows entry counts by action:
+
+- **New**: detected on the device, not yet in NetBox.
+- **Changed**: detected on the device, differs from NetBox.
+- **Confirmed**: detected and matches NetBox.
+- **Stale**: in NetBox (and tagged "Automatically Discovered") but not
+  detected this run.
+
+Each entry shows `detected_values` (what the device reported) and
+`current_values` (what NetBox has, when applicable).
+
+## 5. Apply or skip entries
+
+Tick one or more pending entries and use the **Apply selected** or
+**Skip selected** buttons. Apply runs each entry through its per-collector
+handler in
+[`netbox_facts/helpers/applier.py`](https://github.com/jsenecal/netbox-facts/blob/main/netbox_facts/helpers/applier.py)
+inside a per-entry savepoint, so a failure on one entry does not roll back
+others.
+
+When every entry is resolved (applied, skipped, or failed) the report
+status becomes `Applied` (if any entry was applied) or `Completed`.
+
+## 6. Schedule recurring runs
+
+Edit the plan and set **Interval (minutes)**. The `post_save` signal
+calls `CollectionJobRunner.enqueue_once()`, mirroring NetBox's
+`DataSource` sync pattern. Disabling the plan or clearing the interval
+cancels any pending scheduled job.
+
+See [Scheduling and Jobs](../user-guide/scheduling.md) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,45 @@
-{%
-    include-markdown "../README.md"
-%}
+# NetBox Facts
+
+NetBox Facts is a NetBox 4.5+ plugin that gathers operational facts from
+network devices managed in NetBox via [NAPALM](https://napalm.readthedocs.io/)
+and stores them as queryable records.
+
+## What it does
+
+The plugin connects to devices using the credentials and driver configured
+on a Collection Plan, runs one of ten collector types (ARP, NDP, inventory,
+interfaces, LLDP, ethernet switching, L2 circuits, EVPN, BGP, OSPF), and
+persists what it finds. Results are either:
+
+- written directly to NetBox (apply mode); or
+- captured in a `FactsReport` for review (detect-only mode), where each
+  detected fact is a `FactsReportEntry` that can be applied or skipped
+  individually or in bulk.
+
+Recurring collection is handled by NetBox's `JobRunner` framework so plans
+re-run on a configurable interval.
+
+## When to use it
+
+- You want to keep IP, MAC, neighbor, and chassis inventory data in NetBox
+  in sync with what devices actually report.
+- You want auditable, reviewable changes rather than silent mutations.
+- You operate Junos and want richer ARP/NDP, chassis inventory, EVPN, L2
+  circuits, and OSPF collection out of the box.
+
+## Where to start
+
+- New users: read [Installation](getting-started/installation.md), then
+  [Configuration](getting-started/configuration.md), then
+  [Quick Start](getting-started/quick-start.md).
+- Operators: read [Collection Plans](user-guide/collection-plans.md) and
+  [Detect-Only Workflow](user-guide/detect-only.md).
+- Integrators: read the [REST API](reference/rest-api.md) reference.
+- Plugin developers: read [Architecture](developer/architecture.md) and
+  [Vendor Dispatch](developer/vendor-dispatch.md).
+
+## Project status
+
+Alpha. Compatible with NetBox 4.5.x. Source on
+[GitHub](https://github.com/jsenecal/netbox-facts), released to PyPI as
+`netbox-facts`.

--- a/docs/user-guide/collection-plans.md
+++ b/docs/user-guide/collection-plans.md
@@ -1,0 +1,101 @@
+# Collection Plans
+
+A `CollectionPlan` is the central object that ties together:
+
+- which devices to collect from;
+- which collector to run;
+- which NAPALM driver and credentials to use;
+- whether to mutate NetBox or only produce a report;
+- whether to run once or on an interval.
+
+The model lives at `netbox_facts/models/collection_plan.py`.
+
+## Identity and lifecycle
+
+| Field | Notes |
+|---|---|
+| `name` | Unique. Free-form. |
+| `priority` | One of `high`, `default`, `low`. Maps directly to the RQ queue used at enqueue time. |
+| `status` | Plugin-managed. One of `new`, `queued`, `working`, `completed`, `scheduled`, `failed`, `stalled`. |
+| `enabled` | If `False`, recurring schedules are removed and the plan cannot enqueue. |
+| `description` / `comments` | Free-form text. |
+| `run_as` | Optional user. When set and the requesting user is a superuser, the job runs as this user. |
+
+`stalled` is set automatically by `CollectionPlan.check_stalled()` when the
+plan is `working` but no live job exists.
+
+## Device scoping
+
+The plan exposes the following many-to-many fields that
+`get_devices_queryset()` ANDs together to resolve the device list:
+
+- `devices`, `regions`, `site_groups`, `sites`, `locations`
+- `device_types`, `roles`, `platforms`
+- `tenant_groups`, `tenants`
+- `tags`
+
+Plus an `ArrayField` of `device_status` values from
+`dcim.choices.DeviceStatusChoices`. When empty, no status filter is
+applied.
+
+## Collector type and driver
+
+| Field | Notes |
+|---|---|
+| `collector_type` | One of the values in `CollectionTypeChoices`. See [Collectors Overview](../collectors/index.md). |
+| `napalm_driver` | A NAPALM driver name (e.g. `junos`, `ios`, `eos`). Resolved by `get_network_driver()`; the plugin first tries `netbox_facts.napalm.<name>` so internal vendor overrides win, then falls back to upstream. |
+| `napalm_args` | JSON merged on top of the plugin-level `global_napalm_args`. Special keys `username` and `password` are extracted before the rest is passed as `optional_args`. |
+
+## Connection target
+
+`connection_target` controls dial order:
+
+| Value | Behavior |
+|---|---|
+| `primary` | Use `device.primary_ip` only. |
+| `oob` | Use `device.oob_ip` only. |
+| `primary_then_oob` | Try primary; on `ConnectionException`, try OOB. |
+| `oob_then_primary` | Try OOB; on `ConnectionException`, try primary. |
+
+The IP list is resolved by
+`netbox_facts.helpers.netbox.get_connection_ips()`. A device with no
+usable IP for the chosen target is logged as a warning and skipped.
+
+## Detect-only vs apply mode
+
+`detect_only=True` makes the collector record `FactsReportEntry` rows
+without mutating NetBox. The report is finalized with status `Pending` and
+entries can be applied selectively from the UI or REST API.
+
+`detect_only=False` writes directly. A `FactsReport` is still created so
+every applied object has a record; in this mode entries are marked
+`applied` immediately. The final report status becomes `Applied`.
+
+See [Detect-Only Workflow](detect-only.md) for the full apply flow.
+
+## Scheduling
+
+Scheduling is driven entirely by the `interval` field plus the plan's
+`enabled` flag:
+
+- `interval` blank: the plan does not auto-schedule. Manual runs only.
+- `interval = N`: every save schedules `CollectionJobRunner.enqueue_once()`
+  to run every N minutes via NetBox's `JobRunner` framework.
+- `enabled = False`: the `post_save` signal cancels any pending scheduled
+  job for the plan.
+
+Implementation: see `handle_collection_job_change()` in
+`netbox_facts/signals.py`.
+
+## Logs and history
+
+Each run records a structured log on the `Job.data["log"]` field
+(persisted by `CollectionJobRunner.run()`) and the `last_run` timestamp on
+the plan. Each run also creates exactly one `FactsReport`, linked from
+`plan.reports`.
+
+## Cloning
+
+The plan declares `clone_fields` so the **Clone** action in the UI
+preserves scoping, driver, args, schedule, detect-only, and connection
+target. Name, status, and last_run are reset.

--- a/docs/user-guide/detect-only.md
+++ b/docs/user-guide/detect-only.md
@@ -1,0 +1,121 @@
+# Detect-Only Workflow
+
+Detect-only mode lets a collection plan inspect devices and produce a
+review-able report without changing NetBox. It is the recommended mode for
+new plans, especially in production.
+
+## Enabling
+
+Set the `detect_only` flag on the `CollectionPlan` (UI checkbox, or
+`detect_only=true` via the REST API).
+
+When enabled:
+
+- The collector still connects to every in-scope device.
+- For each detected fact it creates a `FactsReportEntry` with one of four
+  actions and `status = pending`.
+- It does **not** create or modify NetBox objects.
+
+When disabled (apply mode):
+
+- The collector creates entries the same way, then marks each one
+  `applied` immediately after the corresponding NetBox object is written.
+- The final report status is `Applied`.
+
+## Action types
+
+`FactsReportEntry.action` is one of:
+
+| Action | Meaning |
+|---|---|
+| `new` | The fact was detected on the device and no matching object exists in NetBox yet. |
+| `changed` | A matching object exists in NetBox but its values differ from what the device reports. |
+| `confirmed` | The fact matches NetBox exactly. Entries are recorded for visibility; applying them is a no-op for most collectors. |
+| `stale` | The object exists in NetBox (and carries the **Automatically Discovered** tag) but was not seen during this run. Applying it removes or unassigns the object. |
+
+## Entry status
+
+`FactsReportEntry.status` tracks the apply lifecycle:
+
+| Status | Meaning |
+|---|---|
+| `pending` | Default. The entry has not been applied or skipped. |
+| `applied` | The per-collector handler ran successfully. `applied_at` is set. |
+| `skipped` | A reviewer chose not to apply this entry. |
+| `failed` | The handler raised an exception; `error_message` holds the truncated reason (1000 chars). The savepoint for this entry was rolled back; other entries are unaffected. |
+
+## Reviewing a report
+
+Open **Operational Facts -> Facts Reports** and pick a report. The page
+shows:
+
+- A summary card with counts by action (cached on
+  `FactsReport.summary`).
+- The full entry list with filters for `action`, `status`,
+  `collector_type`, and `device`.
+- For each entry: `object_repr`, `detected_values`, `current_values`, and
+  any error message.
+
+`object_repr` is a human-readable label such as
+`MACAddress aa:bb:cc:11:22:33`, `InventoryItem PIC 0`, or
+`Cable ge-0/0/0 <-> switch2:ge-0/0/4`. It is constructed by
+`NapalmCollector._object_repr()`.
+
+## Applying or skipping entries
+
+Tick one or more pending entries and use the **Apply selected** or
+**Skip selected** action.
+
+Apply runs through `apply_entries()` in
+`netbox_facts/helpers/applier.py`:
+
+1. Fetch the requested pending entries scoped to the report.
+2. Open an outer atomic block.
+3. For each entry:
+    - Open a per-entry savepoint.
+    - Look up the collector-type-specific handler in `APPLY_HANDLERS`.
+    - Run the handler. On success, set `status=applied` and
+      `applied_at=now`.
+    - On exception, mark `status=failed`, save the truncated error, and
+      release the inner savepoint so the outer transaction continues.
+4. After the loop, recompute and persist the report status.
+
+The same path is exposed over the REST API:
+
+```http
+POST /api/plugins/facts/factsreports/<id>/apply/
+Content-Type: application/json
+Authorization: Token <token>
+
+{"entries": [12, 13, 19]}
+```
+
+Response: `{"applied": 2, "failed": 1}`.
+
+Skip is similar but does not invoke handlers; it just bulk-updates
+`status=skipped`.
+
+## Report status transitions
+
+`_update_report_status()` derives the report status from its entries:
+
+- All `pending` -> `Pending`.
+- All `applied` -> `Applied` (and `completed_at` is set).
+- All `failed` -> `Failed`.
+- No `pending` left, mix of `applied` and others -> `Applied`.
+- No `pending` left, no `applied` -> `Completed`.
+- Otherwise -> `Partial`.
+
+## Permissions
+
+Applying or skipping requires the `netbox_facts.apply_factsreport`
+permission. Grant it explicitly to the operators who should be allowed to
+mutate NetBox from a report; viewing a report only requires
+`netbox_facts.view_factsreport`.
+
+## Why a savepoint per entry
+
+A handler can fail for many independent reasons (a duplicate IP, a missing
+ModuleType, an interface that has gained a cable since collection). The
+per-entry savepoint guarantees that one bad entry does not undo every
+successful apply that came before it in the same batch.

--- a/docs/user-guide/facts-reports.md
+++ b/docs/user-guide/facts-reports.md
@@ -1,0 +1,79 @@
+# Facts Reports
+
+A `FactsReport` is created by every collection run and accumulates one
+`FactsReportEntry` per detected fact. The model lives at
+`netbox_facts/models/facts_report.py`.
+
+## Report fields
+
+| Field | Notes |
+|---|---|
+| `collection_plan` | FK to `CollectionPlan`. |
+| `job` | FK to the `core.Job` that produced the report. Set after the run completes. |
+| `status` | One of `pending`, `completed`, `partial`, `applied`, `failed`. |
+| `created_by` | User who triggered the run, when available. |
+| `completed_at` | Timestamp set when the report reaches a terminal status. |
+| `summary` | Cached counts by action: `{new, changed, confirmed, stale}`. Recomputed by `update_summary()`. |
+| `error_message` | Populated when a top-level collection failure aborts the run. |
+
+## Entry fields
+
+| Field | Notes |
+|---|---|
+| `report` | FK to the parent report. |
+| `action` | `new`, `changed`, `confirmed`, or `stale`. |
+| `status` | `pending`, `applied`, `skipped`, or `failed`. |
+| `collector_type` | The collector that produced this entry. Determines which apply handler is dispatched. |
+| `device` | The device the fact was detected on. |
+| `object_type` / `object_id` | Generic FK to the NetBox object the entry refers to. Nullable for `new` entries that have not been applied yet. |
+| `object_repr` | Human-readable label (e.g. `Interface ge-0/0/0`, `MACAddress 00:11:22:33:44:55`). |
+| `detected_values` | JSON. What the device reported. |
+| `current_values` | JSON. What NetBox currently has. Empty for `new` entries. |
+| `error_message` | Populated on apply failure (max 1000 chars). |
+| `created`, `applied_at` | Timestamps. |
+
+## Indexes
+
+The entry table indexes `(report, action)`, `(report, status)`, and
+`(object_type, object_id)` for the common UI filter paths.
+
+## Status reconciliation
+
+`FactsReport.status` is derived from its entries by
+`netbox_facts.helpers.applier._update_report_status()`:
+
+| Entry distribution | Resulting status |
+|---|---|
+| All `pending` (or no entries) | `Pending` |
+| All `applied` | `Applied` |
+| All `failed` | `Failed` |
+| No `pending`, contains `applied` | `Applied` |
+| No `pending`, no `applied` (mix of `skipped` / `failed`) | `Completed` |
+| Otherwise | `Partial` |
+
+`completed_at` is stamped whenever the status reaches a non-`Pending`
+state.
+
+## REST endpoints
+
+- `GET /api/plugins/facts/factsreports/` -- list/filter reports.
+- `GET /api/plugins/facts/factsreports/<id>/` -- single report.
+- `POST /api/plugins/facts/factsreports/<id>/apply/` -- apply selected
+  pending entries. Body: `{"entries": [pk, ...]}`.
+- `POST /api/plugins/facts/factsreports/<id>/skip/` -- bulk-skip selected
+  pending entries. Same body.
+
+The `apply` and `skip` endpoints validate that all submitted entry PKs
+belong to the report (returns `400` if not) and are throttled to 30
+requests per minute per user.
+
+## Filters
+
+The list view supports these filters via `FactsReportFilterSet`:
+
+- `q` -- substring match on `collection_plan__name`.
+- `collection_plan` -- one or more plan IDs.
+- `status` -- one or more `ReportStatusChoices` values.
+
+The entry list (within a report) supports `action`, `status`,
+`collector_type`, and `device`.

--- a/docs/user-guide/mac-tracking.md
+++ b/docs/user-guide/mac-tracking.md
@@ -1,0 +1,73 @@
+# MAC Address Tracking
+
+The plugin maintains its own `MACAddress` table (separate from
+`dcim.MACAddress` in core NetBox) so that observed MACs can be tracked
+with discovery metadata and OUI vendor information.
+
+Both models live in `netbox_facts/models/mac.py`.
+
+## MACAddress
+
+| Field | Notes |
+|---|---|
+| `mac_address` | Unique. Stored canonically as colon-separated uppercase. |
+| `description` | Free text. |
+| `vendor` | FK to `MACVendor`. Auto-populated; not user-editable. |
+| `interfaces` | M2M to `dcim.Interface` via `MACAddressInterfaceRelation`. Populated by ARP/NDP, ethernet switching, and EVPN collectors. |
+| `ip_addresses` | M2M to `ipam.IPAddress` via `MACAddressIPAddressRelation`. Populated by ARP/NDP collectors. |
+| `device_interface` | One-to-one to `dcim.Interface`. Set by the **interfaces** collector to record where the MAC is physically owned. |
+| `last_seen` | Timestamp of the most recent collection that touched this MAC. |
+| `discovery_method` | One of `CollectionTypeChoices` values; whichever collector last touched the record. |
+| `comments` | Free text. |
+
+## MACVendor
+
+| Field | Notes |
+|---|---|
+| `manufacturer` | Optional FK to `dcim.Manufacturer`. |
+| `vendor_name` | Free text vendor label (often the OUI registrant). |
+| `mac_prefix` | First 6 bytes of the MAC, unique. Stored as a 24-bit `MACPrefixField`. |
+
+`MACVendorManager.get_by_mac_address(mac)` looks up the vendor by masking
+the MAC to its OUI.
+
+## Auto-vendor lookup
+
+`signals.handle_mac_change` runs on every `MACAddress` save:
+
+1. If `vendor` is unset, try `MACVendor.objects.get_by_mac_address()`.
+2. If no `MACVendor` exists yet, fall back to
+   `MACAddress.vendor_name_from_mac_address` (which queries the bundled
+   `netaddr` IEEE OUI registry).
+3. If a name is found, look up a matching `dcim.Manufacturer`; otherwise
+   inherit the manufacturer from another `MACVendor` with the same name;
+   otherwise leave `manufacturer` null.
+4. Create a new `MACVendor` row with that prefix and the resolved
+   manufacturer.
+
+`signals.handle_mac_vendor_change` runs on every `MACVendor` save: it
+updates every existing `MACAddress` whose first 6 bytes match the prefix
+to point at the saved vendor. This means manually editing a vendor row
+back-fills correctly.
+
+## Interactions with collectors
+
+| Collector | What gets written |
+|---|---|
+| ARP / NDP | `MACAddress.interfaces` (the device's local interface) and `MACAddress.ip_addresses`. The matching `IPAddress` is also created. |
+| Interfaces | `MACAddress.device_interface` (one-to-one). The MAC is recorded as belonging to the device's port. |
+| Ethernet switching | `MACAddress.interfaces` only. Tracks MACs learned in the L2 switching table. |
+| EVPN | Creates the `MACAddress`, sets `discovery_method`, but does not link an interface (the EVPN collector reads from `show evpn mac-table`). |
+
+`last_seen` is refreshed and `discovery_method` is overwritten on every
+write, so it reflects the most recent collector to touch the row.
+
+## REST API
+
+- `GET /api/plugins/facts/macaddresses/` -- list/filter.
+  `interfaces_count` is annotated.
+- `GET /api/plugins/facts/macvendors/` -- list/filter.
+  `instances_count` is annotated.
+
+Filters on `MACAddress`: `mac_address`, `vendor`, `description`.
+Filters on `MACVendor`: `mac_prefix`, `manufacturer`, `vendor_name`.

--- a/docs/user-guide/scheduling.md
+++ b/docs/user-guide/scheduling.md
@@ -1,0 +1,90 @@
+# Scheduling and Jobs
+
+Collection plans run on top of NetBox's `JobRunner` framework. Each plan
+gets its own `CollectionJobRunner` (defined in
+`netbox_facts/jobs.py`).
+
+## Manual runs
+
+From the plan detail page, click **Run** (or `POST` to
+`/api/plugins/facts/collectionplans/<id>/run/`). The view calls
+`CollectionPlan.enqueue_collection_job(request)` which:
+
+1. Refuses to enqueue if `status` is already `queued` or `working`
+   (`OperationNotSupported` -> HTTP `409`).
+2. Picks the user (`run_as` if the requester is a superuser and the field
+   is set, otherwise the requester).
+3. Calls `CollectionJobRunner.enqueue()` with the plan as `instance` and
+   `queue_name=plan.priority` (one of `high`, `default`, `low`).
+
+`enqueue()` injects the plugin's `job_timeout` (default 1800s) when the
+caller does not pass one, then sets the plan's status to `queued`.
+
+## Recurring runs
+
+Set the plan's `interval` (in minutes). The `post_save` signal
+`handle_collection_job_change` calls
+`CollectionJobRunner.enqueue_once(instance=plan, interval=plan.interval, ...)`,
+which is the upstream NetBox idiom that ensures only one scheduled job
+exists per plan.
+
+Unsetting the interval, or disabling the plan, deletes any pending
+scheduled job for that plan.
+
+## Queue priorities
+
+| Priority | RQ queue |
+|---|---|
+| `high` | `high` |
+| `default` | `default` |
+| `low` | `low` |
+
+Queues map directly. Configure RQ workers to drain higher-priority queues
+first if you mix interactive and bulk plans.
+
+## Job lifecycle
+
+`CollectionJobRunner.run()`:
+
+1. Loads the `CollectionPlan` from `self.job.object_id`.
+2. Calls `plan.run(request=request)`, which constructs a `NapalmCollector`
+   and iterates devices.
+3. In a `finally`, copies the in-memory log onto `self.job.data["log"]`
+   so the job results page can display it (even on failure).
+4. Links the most recent `FactsReport` for the plan to this job (if not
+   already linked).
+
+`CollectionPlan.run()` updates plan status:
+
+- Set `working` at the start.
+- Set `completed` and `last_run = now` on success.
+- Set `failed` and re-raise on exception.
+
+`NapalmCollector.execute()` updates report status:
+
+- `Applied` (apply mode) or `Pending` (detect-only) on clean finish.
+- `Failed` and `error_message` on uncaught exception.
+
+## Stalled detection
+
+If a plan is `working` but no live `Job` exists (e.g. a worker crashed),
+`CollectionPlan.check_stalled()` (called from `__init__`) flips its
+status to `stalled`. This is a hint to operators: stalled plans can be
+re-run safely.
+
+## Job timeouts
+
+Two limits cap how long a run can take:
+
+- `napalm_timeout` (plugin-wide, default 60s) is the per-RPC NAPALM
+  timeout. It is injected into `optional_args["timeout"]` before
+  connecting.
+- `job_timeout` (plugin-wide, default 1800s) is the RQ-level cap on the
+  whole job. Long plans (many devices) may need this raised in
+  `PLUGINS_CONFIG`.
+
+## Inspecting jobs
+
+Each plan's **Jobs** tab lists every `core.Job` it has produced. Each job
+links to its `FactsReport` and shows the per-device log written into
+`Job.data["log"]`.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -9,6 +9,43 @@ edit_uri = "edit/main/docs/"
 docs_dir = "."
 nav = [
   { "Home" = "index.md" },
+  { "Getting Started" = [
+    { "Installation" = "getting-started/installation.md" },
+    { "Configuration" = "getting-started/configuration.md" },
+    { "Quick Start" = "getting-started/quick-start.md" },
+  ] },
+  { "User Guide" = [
+    { "Collection Plans" = "user-guide/collection-plans.md" },
+    { "Detect-Only Workflow" = "user-guide/detect-only.md" },
+    { "Facts Reports" = "user-guide/facts-reports.md" },
+    { "MAC Address Tracking" = "user-guide/mac-tracking.md" },
+    { "Scheduling and Jobs" = "user-guide/scheduling.md" },
+  ] },
+  { "Collectors" = [
+    { "Overview" = "collectors/index.md" },
+    { "ARP and NDP" = "collectors/arp-ndp.md" },
+    { "Inventory" = "collectors/inventory.md" },
+    { "Interfaces" = "collectors/interfaces.md" },
+    { "LLDP" = "collectors/lldp.md" },
+    { "Ethernet Switching" = "collectors/ethernet-switching.md" },
+    { "EVPN" = "collectors/evpn.md" },
+    { "L2 Circuits" = "collectors/l2-circuits.md" },
+    { "BGP" = "collectors/bgp.md" },
+    { "OSPF" = "collectors/ospf.md" },
+  ] },
+  { "Reference" = [
+    { "Models" = "reference/models.md" },
+    { "REST API" = "reference/rest-api.md" },
+    { "Settings" = "reference/settings.md" },
+    { "Choices" = "reference/choices.md" },
+    { "Tags and Markers" = "reference/tags.md" },
+  ] },
+  { "Developer Guide" = [
+    { "Architecture" = "developer/architecture.md" },
+    { "Vendor Dispatch" = "developer/vendor-dispatch.md" },
+    { "netbox-routing Integration" = "developer/netbox-routing.md" },
+    { "Testing" = "developer/testing.md" },
+  ] },
   { "Contributing" = "contributing.md" },
   { "Changelog" = "changelog.md" },
 ]


### PR DESCRIPTION
Substantive expansion of the documentation site, generated by a per-plugin exploration pass that traced models, views, REST API, backends, and management commands. Covers user workflows, configuration references, REST API, and developer guides.

Drafted as PRs to land iteratively -- review piece by piece, edit / drop pages where the prose doesn't match operator reality, trim things better suited to code comments. The agent that drafted this had less context than you do; treat as a starting point.

ASCII-only output, no AI / Claude attribution. Conventional-commits PR title.