### PR TITLE
chore(deps): pin Django to 5.2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 keywords = ["netbox", "netbox-plugin", "napalm", "network-automation"]
 dependencies = [
+    "Django>=5.2,<5.3",
     "napalm~=5.1.0",
     "requests~=2.33.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -454,16 +454,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.4"
+version = "5.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
 ]
 
 [[package]]
@@ -819,6 +819,7 @@ wheels = [
 name = "netbox-facts"
 source = { editable = "." }
 dependencies = [
+    { name = "django" },
     { name = "napalm" },
     { name = "requests" },
 ]
@@ -843,6 +844,7 @@ routing = [
 [package.metadata]
 requires-dist = [
     { name = "bump-my-version", marker = "extra == 'dev'" },
+    { name = "django", specifier = ">=5.2,<5.3" },
     { name = "napalm", specifier = "~=5.1.0" },
     { name = "netbox-routing", marker = "extra == 'dev'" },
     { name = "netbox-routing", marker = "extra == 'routing'" },


### PR DESCRIPTION
## Summary
- Adds a `Django>=5.2,<5.3` constraint so the resolver tracks the same major.minor that NetBox 4.5 supports (`Django==5.2.13` upstream).
- Without the pin, uv was resolving to Django 6.0.4 -- incompatible with NetBox at runtime and the subject of three open Dependabot advisories (cache/cookie sensitive data, length-parameter handling).
- `uv.lock` now resolves Django to **5.2.14** (latest 5.2.x).

## Changes
- `pyproject.toml`: add `"Django>=5.2,<5.3"` to `dependencies`.
- `uv.lock`: Django 6.0.4 -> 5.2.14.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (264 passed, 3 skipped on Django 5.2.14)
- [x] No source changes; no new tests required
- [x] No migration changes
- [x] No user-visible behavior change; README compatibility matrix unchanged

## Related
Sidesteps Dependabot alerts #8, #9, #10 (Django 6.0 advisories no longer applicable).