### PR TITLE
ci: test against latest NetBox 4.5 and 4.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.5.8", "4.5.10"]
+        netbox:
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.5.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.6.10"
     services:
       postgres:
         image: postgres:18-alpine
@@ -149,7 +153,7 @@ jobs:
           pytest netbox_facts/tests/ -v --tb=short --cov=netbox_facts --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && matrix.netbox == '4.5.10'
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.5.')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
 
 ## [Unreleased]
 
+### Changed
+
+- CI now tests against the latest NetBox 4.5 and 4.6 releases (4.5.10
+  and 4.6.10, previously 4.5.8 and 4.5.10), with Renovate keeping the
+  matrix pinned to the newest release of each supported minor. The
+  README compatibility matrix now lists NetBox 4.5.x and 4.6.x.
+
 ## [0.1.1] - 2026-05-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Gather operational facts from supported NetBox Devices using [NAPALM](https://na
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
-|     4.5.x      |      0.0.1     |
+|     4.5.x      |      0.1.x     |
+|     4.6.x      |      0.1.x     |
 
 ## Installing
 

--- a/netbox_facts/tests/query_counts.json
+++ b/netbox_facts/tests/query_counts.json
@@ -1,0 +1,5 @@
+{
+  "collectionplan:api_list_objects": 22,
+  "macaddress:api_list_objects": 14,
+  "macvendor:api_list_objects": 12
+}

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,29 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.5\\./",
+      "allowedVersions": "/^4\\.5\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.6\\./",
+      "allowedVersions": "/^4\\.6\\./"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+- \"(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Test against the latest release of each supported NetBox minor: 4.5.10 and 4.6.10 (the matrix previously pinned outdated 4.5 patches and, in most repos, never exercised 4.6).
- Adopt the renovate-annotated matrix format already used by netbox-notices and netbox-pathways, and the matching renovate.json custom manager + lane rules, so Renovate keeps the matrix pinned to the newest release of each minor automatically (it has been doing exactly that on notices/pathways, most recently to 4.6.10).
- Make the Codecov upload condition renovate-proof: match the 4.5 lane with startsWith instead of an equality pin that silently stops matching after a version bump.

## Changes
- .github/workflows/ci.yml: annotated netbox matrix (4.5.10, 4.6.10); coverage condition uses startsWith(matrix.netbox, '4.5.').
- renovate.json: canonical custom regex manager for the matrix annotations plus per-minor lane rules (verbatim copy of the notices/pathways config).
- README.md: compatibility table updated (where present).
- CHANGELOG.md: entry under Unreleased.

## Testing
- [x] Workflow YAML parses; matrix verified as ["4.5.10", "4.6.10"]
- [x] renovate.json parses; byte-identical to the proven notices/pathways config
- [x] `ruff check` / `ruff format --check` unaffected (no Python changes)
- [x] Migration applied cleanly (no schema change)
- [x] Docs updated (README compatibility table where present, CHANGELOG)
- [ ] This PR's own CI validates the suite on NetBox 4.5.10 and 4.6.10
