### PR TITLE
chore: add NetBox 4.7 support

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,14 +1,29 @@
-#!/bin/bash
-# Reject commits with Claude attributions
+#!/usr/bin/env bash
+# Reject commits that contain AI / Claude attribution lines.
+# Matches the *structure* of attribution lines (trailers, generator
+# tags, bot emails) rather than the bare words "claude" / "anthropic",
+# so legitimate mentions in commit subjects/bodies (dependency bumps,
+# CHANGELOG entries, etc.) are not blocked.
+set -eu
 
-commit_msg_file="$1"
-commit_msg=$(cat "$commit_msg_file")
+msg_file=$1
 
-# Check for Claude attributions (case-insensitive)
-if echo "$commit_msg" | grep -iqE "(claude|anthropic|Generated with.*Claude|Co-Authored-By:.*Claude)"; then
-    echo "ERROR: Commit message contains Claude attribution."
-    echo "Please remove any references to Claude, Anthropic, or AI-generated content."
-    exit 1
-fi
+patterns=(
+    '^[[:space:]]*Co-[Aa]uthored-[Bb]y:.*([Cc]laude|[Aa]nthropic|@anthropic\.com)'
+    '🤖[[:space:]]*[Gg]enerated'
+    '[Gg]enerated[[:space:]]+(with|by)[[:space:]]+\[?[Cc]laude'
+    '[Gg]enerated[[:space:]]+(with|by)[[:space:]]+.*[Aa]nthropic'
+    '\[Claude Code\]'
+    'noreply@anthropic\.com'
+)
+
+for p in "${patterns[@]}"; do
+    if grep -qE "$p" "$msg_file"; then
+        echo "ERROR: commit message contains AI / Claude attribution." >&2
+        echo "       Matched pattern: $p" >&2
+        echo "       Remove the line and re-commit (do NOT use --no-verify)." >&2
+        exit 1
+    fi
+done
 
 exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           - "4.5.10"
           # renovate: datasource=github-releases depName=netbox-community/netbox
           - "4.6.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.7.0"
     services:
       postgres:
         image: postgres:18-alpine
@@ -153,7 +155,7 @@ jobs:
           pytest netbox_facts/tests/ -v --tb=short --cov=netbox_facts --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.5.')
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.7.')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,22 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
 
 ## [Unreleased]
 
+### Added
+
+- `FactsConfig` now declares `min_version = "4.5.0"` and
+  `max_version = "4.7.99"`. NetBox refuses to start with an out-of-range
+  release instead of failing later with an obscure import or template
+  error.
+
 ### Changed
 
+- NetBox 4.7 support. CI adds a 4.7.0 lane alongside 4.5.10 and 4.6.10,
+  Renovate keeps a `4.7.x` lane pinned to the newest release of that
+  minor, and the coverage upload now runs on the 4.7 lane. The README
+  and docs compatibility lists add NetBox 4.7.x.
+- Dropped the `Django>=5.2,<5.3` runtime dependency. NetBox pins the
+  Django version it supports, and the plugin-side pin conflicted with
+  NetBox 4.7, which ships Django 6.1.
 - CI now tests against the latest NetBox 4.5 and 4.6 releases (4.5.10
   and 4.6.10, previously 4.5.8 and 4.5.10), with Renovate keeping the
   matrix pinned to the newest release of each supported minor. The

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Gather operational facts from supported NetBox Devices using [NAPALM](https://na
 |----------------|----------------|
 |     4.5.x      |      0.1.x     |
 |     4.6.x      |      0.1.x     |
+|     4.7.x      |      0.1.x     |
 
 ## Installing
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- NetBox 4.5.x
+- NetBox 4.5.x, 4.6.x, or 4.7.x
 - Python 3.12, 3.13, or 3.14
 - A reachable PostgreSQL database and Redis (the standard NetBox stack)
 - NAPALM-compatible network devices

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,6 @@ re-run on a configurable interval.
 
 ## Project status
 
-Alpha. Compatible with NetBox 4.5.x. Source on
+Alpha. Compatible with NetBox 4.5.x through 4.7.x. Source on
 [GitHub](https://github.com/jsenecal/netbox-facts), released to PyPI as
 `netbox-facts`.

--- a/netbox_facts/__init__.py
+++ b/netbox_facts/__init__.py
@@ -22,6 +22,8 @@ class FactsConfig(PluginConfig):
     base_url = "facts"
     author = "Jonathan Senecal"
     author_email = "contact@jonathansenecal.com"
+    min_version = "4.5.0"
+    max_version = "4.7.99"
     default_settings = {
         "top_level_menu": True,
         "napalm_username": "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 keywords = ["netbox", "netbox-plugin", "napalm", "network-automation"]
 dependencies = [
-    "Django>=5.2,<5.3",
     "napalm~=5.2.0",
     "requests~=2.34.0",
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["netbox-community/netbox"],
       "matchCurrentValue": "/^4\\.6\\./",
       "allowedVersions": "/^4\\.6\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.7\\./",
+      "allowedVersions": "/^4\\.7\\./"
     }
   ],
   "customManagers": [

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,6 @@ wheels = [
 name = "netbox-facts"
 source = { editable = "." }
 dependencies = [
-    { name = "django" },
     { name = "napalm" },
     { name = "requests" },
 ]
@@ -842,7 +841,6 @@ routing = [
 [package.metadata]
 requires-dist = [
     { name = "bump-my-version", marker = "extra == 'dev'" },
-    { name = "django", specifier = ">=5.2,<5.3" },
     { name = "napalm", specifier = "~=5.2.0" },
     { name = "netbox-routing", marker = "extra == 'dev'" },
     { name = "netbox-routing", marker = "extra == 'routing'" },


### PR DESCRIPTION
## Summary
- Drops the `Django>=5.2,<5.3` runtime pin (NetBox owns the Django version; the pin was unresolvable next to 4.7's Django 6.1 and was already downgrading shared 4.6 environments). uv.lock re-locked; Django remains only as a transitive dependency.
- Declares the supported NetBox range in FactsConfig (min 4.5.0, max 4.7.99), previously undeclared.
- Adds NetBox 4.7.0 to the CI matrix (keeping 4.5.10/4.6.10), moves the Codecov upload to the 4.7 lane, adds the Renovate per-minor lane.
- query_counts.json needed no regeneration: re-recording under UPDATE_QUERY_COUNTS=1 on 4.7.0 produced a byte-identical file (4.7.0 counts match the 4.6.10 baselines; the 4.5 lane predates the harness).
- Aligns .githooks/commit-msg with the canonical structural hook already tracked in .git-template/hooks (the stale copy shadowed it via core.hooksPath and rejected legitimate mentions, diverging from every other owned plugin).
- Docs: CHANGELOG entry, README 4.7.x row, docs/index.md and installation.md updated (both were stale at "4.5.x only" since the 4.6 lane landed).

## Changes
- pyproject.toml, uv.lock: Django pin removed
- netbox_facts/__init__.py: min_version/max_version declared
- .github/workflows/ci.yml, renovate.json: 4.7.0 lane, codecov anchor, renovate lane
- .githooks/commit-msg: canonical structural hook
- CHANGELOG.md, README.md, docs/: 4.7 support declared

## Testing
- [x] Baseline-consuming API tests on 4.7.0: 3 passed against existing baselines; UPDATE_QUERY_COUNTS re-record diff empty
- [x] ScriptResultView coupling verified on 4.7.0: import OK, get_table signature unchanged, extras/htmx/script_result.html resolves
- [x] FactsConfig loads on 4.7.0 with the new version bounds
- [x] `ruff check` / `ruff format` clean on the touched Python file
- [ ] Full suite across all three lanes -- left to this PR's CI run

## Follow-ups
- Manual: exercise CollectorResultsView end to end in a browser (queue a collection job, open Results, HTMX path) -- no test covers the view render.
- Decision needed: the untracked `.devcontainer/netbox-facts/` directory in local checkouts is a stale June-2024 working copy with its own .git and uncommitted modifications; it is gitignored, so there is nothing to delete in the repository -- removing it is a local, irreversible cleanup per machine.
- Core custom-script machinery is deprecated for removal in NetBox v5.0; plan to vendor the result-rendering view/template before then.

## Related
Closes #40
