### PR TITLE
fix(models): repair driver loading, config leaks, and first-run stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
 
 ## [Unreleased]
 
+### Fixed
+
+- `CollectionPlan.get_napalm_driver` no longer routes plugin-local driver names through napalm's `get_network_driver`, which rejects dotted module paths under napalm 5.2.0 and made every collection run fail before contacting a device. (#42)
+- `CollectionPlan.get_napalm_args` no longer mutates the live `PLUGINS_CONFIG` dict, which leaked one plan's NAPALM arguments (including username/password overrides) into every later plan run in the same worker process. (#58)
+- Credential values (`username`, `password`, `secret`) stored in a plan's NAPALM arguments are now censored in REST API responses and in the edit form; submitting the censored values back preserves the stored real values. (#59)
+- Loading a collection plan during its first-ever run no longer flips its status to `stalled`, which allowed a second concurrent collection to be enqueued against the same devices mid-run. (#60)
+
 ### Added
 
 - `FactsConfig` now declares `min_version = "4.5.0"` and

--- a/netbox_facts/api/serializers.py
+++ b/netbox_facts/api/serializers.py
@@ -6,6 +6,7 @@ while Django itself handles the database abstraction.
 from netbox.api.serializers import NetBoxModelSerializer
 from rest_framework import serializers
 
+from ..helpers.napalm import mask_napalm_credentials, restore_masked_credentials
 from ..models import CollectionPlan, FactsReport, FactsReportEntry, MACAddress, MACVendor
 from .nested_serializers import NestedMACVendorSerializer
 
@@ -97,6 +98,19 @@ class CollectionPlanSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="plugins-api:netbox_facts-api:collectionplan-detail",
     )
+
+    def to_representation(self, instance):
+        """Censor credential values stored in napalm_args."""
+        data = super().to_representation(instance)
+        if data.get("napalm_args"):
+            data["napalm_args"] = mask_napalm_credentials(data["napalm_args"])
+        return data
+
+    def validate_napalm_args(self, value):
+        """Keep stored credentials when a client round-trips censored values."""
+        if value and self.instance is not None:
+            value = restore_masked_credentials(value, self.instance.napalm_args)
+        return value
 
     class Meta:
         """

--- a/netbox_facts/forms.py
+++ b/netbox_facts/forms.py
@@ -22,6 +22,7 @@ from utilities.forms.widgets.datetime import DateTimePicker
 from utilities.forms.widgets.misc import NumberWithOptions
 
 from netbox_facts.helpers.collector import HAS_NETBOX_ROUTING
+from netbox_facts.helpers.napalm import mask_napalm_credentials, restore_masked_credentials
 
 from .choices import (
     CollectionTypeChoices,
@@ -296,6 +297,16 @@ class CollectorForm(NetBoxModelForm):
             ]
         now = local_now().strftime("%Y-%m-%d %H:%M:%S %Z")
         self.fields["scheduled_at"].help_text += _(" (current server time: <strong>{now}</strong>)").format(now=now)
+        # Censor stored credentials instead of rendering them verbatim
+        if self.instance.pk and isinstance(self.instance.napalm_args, dict):
+            self.initial["napalm_args"] = mask_napalm_credentials(self.instance.napalm_args)
+
+    def clean_napalm_args(self):
+        """Keep stored credentials when the censored values are submitted unchanged."""
+        value = self.cleaned_data.get("napalm_args")
+        if value and self.instance.pk and isinstance(value, dict):
+            value = restore_masked_credentials(value, self.instance.napalm_args)
+        return value
 
     def clean(self):
         scheduled_time = self.cleaned_data.get("scheduled_at")

--- a/netbox_facts/helpers/napalm.py
+++ b/netbox_facts/helpers/napalm.py
@@ -1,6 +1,33 @@
 from collections.abc import Generator
 from typing import Any
 
+from netbox.constants import CENSOR_TOKEN
+
+NAPALM_SENSITIVE_KEYS = ("username", "password", "secret")
+
+
+def mask_napalm_credentials(napalm_args: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of napalm_args with credential values censored."""
+    masked = dict(napalm_args)
+    for key in NAPALM_SENSITIVE_KEYS:
+        if masked.get(key):
+            masked[key] = CENSOR_TOKEN
+    return masked
+
+
+def restore_masked_credentials(incoming: dict[str, Any], stored: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of incoming args with censored values restored from stored ones.
+
+    A censored value round-tripped by a client means "keep the current
+    credential"; it must never overwrite the stored real value.
+    """
+    restored = dict(incoming)
+    stored = stored if isinstance(stored, dict) else {}
+    for key in NAPALM_SENSITIVE_KEYS:
+        if restored.get(key) == CENSOR_TOKEN and key in stored:
+            restored[key] = stored[key]
+    return restored
+
 
 def parse_network_instances(instances) -> dict[str, dict[str, str | list[str] | None]]:
     """Parse network instances"""

--- a/netbox_facts/models/collection_plan.py
+++ b/netbox_facts/models/collection_plan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from datetime import timedelta
 from typing import Any
@@ -278,12 +279,20 @@ class CollectionPlan(NetBoxModel, EventRulesMixin, JobsMixin):
         return napalm_args
 
     def get_napalm_driver(self) -> type[NetworkDriver]:
-        """Return a NAPALM driver instance."""
+        """Return a NAPALM driver class, preferring plugin-local enhanced drivers.
+
+        Plugin-local drivers are imported directly because napalm's
+        get_network_driver() rejects dotted module paths outside its own
+        namespaces before attempting any import.
+        """
         try:
-            driver = get_network_driver(f"netbox_facts.napalm.{self.napalm_driver}")
+            module = importlib.import_module(f"netbox_facts.napalm.{self.napalm_driver}")
         except ModuleNotFoundError:
-            driver = get_network_driver(self.napalm_driver)
-        return driver
+            return get_network_driver(self.napalm_driver)
+        for obj in vars(module).values():
+            if isinstance(obj, type) and issubclass(obj, NetworkDriver) and obj.__module__ == module.__name__:
+                return obj
+        return get_network_driver(self.napalm_driver)
 
     def enqueue_collection_job(self, request):
         """

--- a/netbox_facts/models/collection_plan.py
+++ b/netbox_facts/models/collection_plan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib
 import logging
 from datetime import timedelta
@@ -273,8 +274,13 @@ class CollectionPlan(NetBoxModel, EventRulesMixin, JobsMixin):
         return Device.objects.filter(q).distinct()
 
     def get_napalm_args(self) -> dict[str, Any]:
-        """Return the NAPALM arguments to use when initiating the driver."""
-        napalm_args = get_plugin_config("netbox_facts", "global_napalm_args", {})
+        """Return the NAPALM arguments to use when initiating the driver.
+
+        The merged result is a deep copy: get_plugin_config() returns the
+        live settings object, and callers pop credentials from and inject
+        keys into the returned dict.
+        """
+        napalm_args = copy.deepcopy(get_plugin_config("netbox_facts", "global_napalm_args", {}) or {})
         napalm_args.update(self.napalm_args if self.napalm_args else {})
         return napalm_args
 

--- a/netbox_facts/models/collection_plan.py
+++ b/netbox_facts/models/collection_plan.py
@@ -203,8 +203,15 @@ class CollectionPlan(NetBoxModel, EventRulesMixin, JobsMixin):
         return self.last_run + timedelta(minutes=self.interval)
 
     def check_stalled(self):
-        """Update the status of the collector if stalled."""
-        if self.pk and self.current_job is None and self.status == CollectorStatusChoices.WORKING:
+        """Update the status of the collector if stalled.
+
+        A WORKING plan without a last_run is in its first-ever run:
+        get_current_job() cannot identify the running job without a
+        last_run reference, so this opportunistic check must not touch
+        it. Genuinely stuck first runs are recovered by the
+        recover_stale_jobs management command.
+        """
+        if self.pk and self.last_run and self.current_job is None and self.status == CollectorStatusChoices.WORKING:
             job = self.get_current_job()
             if job is None:
                 self.status = CollectorStatusChoices.STALLED

--- a/netbox_facts/tests/test_plan_lifecycle_regressions.py
+++ b/netbox_facts/tests/test_plan_lifecycle_regressions.py
@@ -1,6 +1,7 @@
 """Regression tests for CollectionPlan lifecycle and credential handling."""
 
 from dcim.choices import DeviceStatusChoices
+from django.conf import settings
 from django.test import TestCase
 
 from netbox_facts.choices import CollectionTypeChoices
@@ -44,3 +45,52 @@ class GetNapalmDriverTest(TestCase):
 
         plan = _build_plan(napalm_driver="eos")
         self.assertIs(plan.get_napalm_driver(), EOSDriver)
+
+
+class GetNapalmArgsIsolationTest(TestCase):
+    """Tests that get_napalm_args never mutates the shared plugin config."""
+
+    def setUp(self):
+        self.plugin_config = settings.PLUGINS_CONFIG["netbox_facts"]
+        self.original_global_args = self.plugin_config.get("global_napalm_args")
+        self.plugin_config["global_napalm_args"] = {"transport": "ssh"}
+
+    def tearDown(self):
+        self.plugin_config["global_napalm_args"] = self.original_global_args
+
+    def test_get_napalm_args_leaves_global_config_untouched(self):
+        """Regression test for issue #58.
+
+        get_napalm_args() merged per-plan args (including credentials)
+        directly into the live PLUGINS_CONFIG dict, leaking them into
+        every later plan run in the same worker process.
+        """
+        plan_with_creds = _build_plan(
+            name="Creds Plan",
+            napalm_args={"username": "plan-user", "password": "plan-pass"},
+        )
+        plan_plain = _build_plan(name="Plain Plan", napalm_args={"timeout": 5})
+
+        merged = plan_with_creds.get_napalm_args()
+        self.assertEqual(merged["username"], "plan-user")
+        self.assertEqual(merged["transport"], "ssh")
+        self.assertEqual(self.plugin_config["global_napalm_args"], {"transport": "ssh"})
+
+        other = plan_plain.get_napalm_args()
+        self.assertNotIn("username", other)
+        self.assertNotIn("password", other)
+        self.assertEqual(other, {"transport": "ssh", "timeout": 5})
+
+    def test_credential_pops_do_not_reach_global_config(self):
+        """Regression test for issue #58.
+
+        NapalmCollector.__init__ pops username/password and injects a
+        timeout into the dict returned by get_napalm_args(); none of
+        that may reach the shared global config.
+        """
+        plan = _build_plan(name="Popping Plan", napalm_args={"username": "u", "password": "p"})
+        merged = plan.get_napalm_args()
+        merged.pop("username")
+        merged.pop("password")
+        merged["timeout"] = 60
+        self.assertEqual(self.plugin_config["global_napalm_args"], {"transport": "ssh"})

--- a/netbox_facts/tests/test_plan_lifecycle_regressions.py
+++ b/netbox_facts/tests/test_plan_lifecycle_regressions.py
@@ -4,7 +4,7 @@ from dcim.choices import DeviceStatusChoices
 from django.conf import settings
 from django.test import TestCase
 
-from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.choices import CollectionTypeChoices, CollectorStatusChoices
 from netbox_facts.models import CollectionPlan
 
 
@@ -94,3 +94,28 @@ class GetNapalmArgsIsolationTest(TestCase):
         merged.pop("password")
         merged["timeout"] = 60
         self.assertEqual(self.plugin_config["global_napalm_args"], {"transport": "ssh"})
+
+
+class CheckStalledFirstRunTest(TestCase):
+    """Tests that loading a plan during its first run does not stall it."""
+
+    def test_first_run_working_plan_is_not_marked_stalled(self):
+        """Regression test for issue #60.
+
+        During a plan's first-ever run, status is WORKING while last_run
+        is still None. get_current_job() cannot find the running job
+        without last_run, so check_stalled() flipped the row to STALLED
+        on any model instantiation (list view, API read), defeating the
+        concurrency guard. Genuinely stuck plans are recovered by the
+        recover_stale_jobs management command instead.
+        """
+        plan = _build_plan(name="First Run Plan")
+        plan.save()
+        CollectionPlan.objects.filter(pk=plan.pk).update(status=CollectorStatusChoices.WORKING)
+
+        reloaded = CollectionPlan.objects.get(pk=plan.pk)
+        self.assertEqual(reloaded.status, CollectorStatusChoices.WORKING)
+        self.assertEqual(
+            CollectionPlan.objects.values_list("status", flat=True).get(pk=plan.pk),
+            CollectorStatusChoices.WORKING,
+        )

--- a/netbox_facts/tests/test_plan_lifecycle_regressions.py
+++ b/netbox_facts/tests/test_plan_lifecycle_regressions.py
@@ -1,10 +1,17 @@
 """Regression tests for CollectionPlan lifecycle and credential handling."""
 
+import json
+
 from dcim.choices import DeviceStatusChoices
 from django.conf import settings
 from django.test import TestCase
+from netbox.constants import CENSOR_TOKEN
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
+from netbox_facts.api.serializers import CollectionPlanSerializer
 from netbox_facts.choices import CollectionTypeChoices, CollectorStatusChoices
+from netbox_facts.forms import CollectorForm
 from netbox_facts.models import CollectionPlan
 
 
@@ -119,3 +126,89 @@ class CheckStalledFirstRunTest(TestCase):
             CollectionPlan.objects.values_list("status", flat=True).get(pk=plan.pk),
             CollectorStatusChoices.WORKING,
         )
+
+
+class NapalmArgsCredentialExposureTest(TestCase):
+    """Tests that napalm_args credentials are masked on read paths."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.plan = CollectionPlan.objects.create(
+            name="Credential Plan",
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            napalm_driver="junos",
+            device_status=[DeviceStatusChoices.STATUS_ACTIVE],
+            napalm_args={"username": "svc-user", "password": "s3cret", "timeout": 15},
+        )
+
+    @staticmethod
+    def _serializer_context():
+        return {"request": Request(APIRequestFactory().get("/"))}
+
+    def test_api_representation_masks_credentials(self):
+        """Regression test for issue #59.
+
+        The REST API serialized napalm_args verbatim, exposing per-plan
+        device credentials to anyone with view permission on the plan.
+        """
+        data = CollectionPlanSerializer(self.plan, context=self._serializer_context()).data
+        self.assertEqual(data["napalm_args"]["username"], CENSOR_TOKEN)
+        self.assertEqual(data["napalm_args"]["password"], CENSOR_TOKEN)
+        self.assertEqual(data["napalm_args"]["timeout"], 15)
+
+    def test_api_update_with_masked_values_preserves_credentials(self):
+        """Regression test for issue #59.
+
+        A PATCH that round-trips the masked representation must not
+        overwrite the stored real credential values.
+        """
+        serializer = CollectionPlanSerializer(
+            self.plan,
+            data={"napalm_args": {"username": CENSOR_TOKEN, "password": CENSOR_TOKEN, "timeout": 30}},
+            partial=True,
+            context=self._serializer_context(),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        plan = serializer.save()
+        self.assertEqual(plan.napalm_args["username"], "svc-user")
+        self.assertEqual(plan.napalm_args["password"], "s3cret")
+        self.assertEqual(plan.napalm_args["timeout"], 30)
+
+    def test_form_initial_masks_credentials(self):
+        """Regression test for issue #59.
+
+        The edit form rendered the stored napalm_args JSON verbatim,
+        exposing credentials in the UI.
+        """
+        form = CollectorForm(instance=self.plan)
+        self.assertEqual(form.initial["napalm_args"]["username"], CENSOR_TOKEN)
+        self.assertEqual(form.initial["napalm_args"]["password"], CENSOR_TOKEN)
+        self.assertEqual(form.initial["napalm_args"]["timeout"], 15)
+        self.plan.refresh_from_db()
+        self.assertEqual(self.plan.napalm_args["password"], "s3cret")
+
+    def test_form_masked_submission_preserves_credentials(self):
+        """Regression test for issue #59.
+
+        Submitting the edit form with the masked values unchanged must
+        not overwrite the stored real credential values.
+        """
+        form = CollectorForm(
+            data={
+                "name": self.plan.name,
+                "priority": self.plan.priority,
+                "collector_type": self.plan.collector_type,
+                "napalm_driver": self.plan.napalm_driver,
+                "connection_target": self.plan.connection_target,
+                "device_status": [DeviceStatusChoices.STATUS_ACTIVE],
+                "napalm_args": json.dumps(
+                    {"username": CENSOR_TOKEN, "password": CENSOR_TOKEN, "timeout": 30},
+                ),
+            },
+            instance=self.plan,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        plan = form.save()
+        self.assertEqual(plan.napalm_args["username"], "svc-user")
+        self.assertEqual(plan.napalm_args["password"], "s3cret")
+        self.assertEqual(plan.napalm_args["timeout"], 30)

--- a/netbox_facts/tests/test_plan_lifecycle_regressions.py
+++ b/netbox_facts/tests/test_plan_lifecycle_regressions.py
@@ -1,0 +1,46 @@
+"""Regression tests for CollectionPlan lifecycle and credential handling."""
+
+from dcim.choices import DeviceStatusChoices
+from django.test import TestCase
+
+from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.models import CollectionPlan
+
+
+def _build_plan(**kwargs):
+    """Return an unsaved CollectionPlan with sensible defaults."""
+    defaults = {
+        "name": "Lifecycle Test Plan",
+        "collector_type": CollectionTypeChoices.TYPE_ARP,
+        "napalm_driver": "junos",
+        "device_status": [DeviceStatusChoices.STATUS_ACTIVE],
+    }
+    defaults.update(kwargs)
+    return CollectionPlan(**defaults)
+
+
+class GetNapalmDriverTest(TestCase):
+    """Tests for CollectionPlan.get_napalm_driver driver resolution."""
+
+    def test_plugin_driver_resolved_for_junos(self):
+        """Regression test for issue #42.
+
+        Under napalm 5.2.0, get_network_driver() rejects dotted driver
+        names before importing them, so the plugin-local enhanced driver
+        must be loaded directly instead of through napalm's loader.
+        """
+        from netbox_facts.napalm.junos import EnhancedJunOSDriver
+
+        plan = _build_plan(napalm_driver="junos")
+        self.assertIs(plan.get_napalm_driver(), EnhancedJunOSDriver)
+
+    def test_stock_driver_resolved_for_eos(self):
+        """Regression test for issue #42.
+
+        A driver without a plugin-local override must fall back to the
+        stock napalm driver instead of raising ModuleImportError.
+        """
+        from napalm.eos import EOSDriver
+
+        plan = _build_plan(napalm_driver="eos")
+        self.assertIs(plan.get_napalm_driver(), EOSDriver)


### PR DESCRIPTION
## Summary
- Repairs the four plan-lifecycle defects that made collection runs fail or leak state: driver loading broken under napalm 5.2.0, per-plan NAPALM args mutating the live plugin config, plaintext credential exposure, and first-run plans being flipped to stalled by any read.
- All four were found by the 2026-09-05 collector code review and verified against the pinned napalm 5.2.0 and NetBox sources.

## Changes
- netbox_facts/models/collection_plan.py: get_napalm_driver imports plugin-local drivers via importlib instead of napalm's dotted-name loader; get_napalm_args deep-copies the global config before merging; check_stalled requires last_run before marking a plan stalled.
- netbox_facts/helpers/napalm.py: new mask_napalm_credentials / restore_masked_credentials helpers using NetBox's CENSOR_TOKEN.
- netbox_facts/api/serializers.py, netbox_facts/forms.py: napalm_args credentials censored on read, merge-preserved on write.
- netbox_facts/tests/test_plan_lifecycle_regressions.py: 9 regression tests, each red on the pre-fix code.
- CHANGELOG.md: entries under Unreleased / Fixed.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (full plugin suite: 291 passed, 18 pre-existing skips)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG; further credential-guidance doc updates tracked in #59 notes)

## Related
Fixes #42
Fixes #58
Fixes #59
Fixes #60
