### PR TITLE
fix(collector): make ARP/NDP collection portable and error-isolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
   matrix pinned to the newest release of each supported minor. The
   README compatibility matrix now lists NetBox 4.5.x and 4.6.x.
 
+### Fixed
+
+- ARP/NDP collection no longer aborts on standard NAPALM drivers that return neighbor IPs as strings, and execute() no longer disguises collector-body AttributeErrors as NotImplementedError (#43).
+- RPC errors raised while iterating the enhanced Junos generator getters are now translated to NAPALM exceptions and handled per device instead of aborting the whole run (#44).
+- Drivers without get_network_instances (e.g. iosxr) no longer abort ARP/interface collection; VRF context degrades to an empty mapping with an informational log (#45).
+- ARP/NDP report entries now record the VRF name instead of str(VRF), so detect-then-apply resolves the VRF instead of silently writing IPs into the global table when the VRF has a route distinguisher (#52).
+
 ## [0.1.1] - 2026-05-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
 - `CollectionPlan.get_napalm_args` no longer mutates the live `PLUGINS_CONFIG` dict, which leaked one plan's NAPALM arguments (including username/password overrides) into every later plan run in the same worker process. (#58)
 - Credential values (`username`, `password`, `secret`) stored in a plan's NAPALM arguments are now censored in REST API responses and in the edit form; submitting the censored values back preserves the stored real values. (#59)
 - Loading a collection plan during its first-ever run no longer flips its status to `stalled`, which allowed a second concurrent collection to be enqueued against the same devices mid-run. (#60)
+- ARP/NDP collection no longer aborts on standard NAPALM drivers that return neighbor IPs as strings, and execute() no longer disguises collector-body AttributeErrors as NotImplementedError (#43).
+- RPC errors raised while iterating the enhanced Junos generator getters are now translated to NAPALM exceptions and handled per device instead of aborting the whole run (#44).
+- Drivers without get_network_instances (e.g. iosxr) no longer abort ARP/interface collection; VRF context degrades to an empty mapping with an informational log (#45).
+- ARP/NDP report entries now record the VRF name instead of str(VRF), so detect-then-apply resolves the VRF instead of silently writing IPs into the global table when the VRF has a route distinguisher (#52).
 
 ### Added
 
@@ -37,13 +41,6 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
   and 4.6.10, previously 4.5.8 and 4.5.10), with Renovate keeping the
   matrix pinned to the newest release of each supported minor. The
   README compatibility matrix now lists NetBox 4.5.x and 4.6.x.
-
-### Fixed
-
-- ARP/NDP collection no longer aborts on standard NAPALM drivers that return neighbor IPs as strings, and execute() no longer disguises collector-body AttributeErrors as NotImplementedError (#43).
-- RPC errors raised while iterating the enhanced Junos generator getters are now translated to NAPALM exceptions and handled per device instead of aborting the whole run (#44).
-- Drivers without get_network_instances (e.g. iosxr) no longer abort ARP/interface collection; VRF context degrades to an empty mapping with an informational log (#45).
-- ARP/NDP report entries now record the VRF name instead of str(VRF), so detect-then-apply resolves the VRF instead of silently writing IPs into the global table when the VRF has a route distinguisher (#52).
 
 ## [0.1.1] - 2026-05-01
 

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -6,6 +6,7 @@ import ipaddress
 import re
 from collections.abc import Generator
 from itertools import groupby
+from types import GeneratorType
 from typing import TYPE_CHECKING, Any
 
 import django.core.exceptions
@@ -1952,10 +1953,16 @@ class NapalmCollector:
     def _napalm_rpc(self, call, label, *args, **kwargs):
         """Execute a NAPALM RPC call with standard error handling.
 
-        Returns the call result, or None if the call failed.
+        Returns the call result, or None if the call failed. Generator
+        results are materialized here because generator getters only run
+        their RPC at iteration time; without this, iteration-time errors
+        would escape the callers and abort the whole run.
         """
         try:
-            return call(*args, **kwargs)
+            result = call(*args, **kwargs)
+            if isinstance(result, GeneratorType):
+                result = list(result)
+            return result
         except (CommandErrorException, CommandTimeoutException, ConnectionException) as exc:
             self._log_failure(f"Failed to retrieve {label}: {exc}")
             return None

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -187,9 +187,17 @@ class NapalmCollector:
         entry.save(update_fields=update_fields)
 
     def _get_network_instances(self, driver: NetworkDriver) -> Generator[tuple[str, dict], None, None]:
-        """Get network instances organized by interface from a device."""
+        """Get network instances organized by interface from a device.
+
+        Drivers without get_network_instances support (e.g. iosxr) yield an
+        empty mapping so the collectors that rely on this data proceed
+        without VRF context instead of aborting the run.
+        """
+        instances = self._napalm_rpc(driver.get_network_instances, "network instances")
+        if instances is None:
+            instances = {}
         return get_network_instances_by_interface(
-            resolve_napalm_network_instances(parse_network_instances(driver.get_network_instances()))
+            resolve_napalm_network_instances(parse_network_instances(instances))
         )
 
     def _ip_neighbors(

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -271,10 +271,14 @@ class NapalmCollector:
                     # Skip unreachable ARP entries
                     continue
 
-                # Build a proper ip_interface_object from the IP and prefix length
+                # Build a proper ip_interface_object from the IP and prefix length.
+                # Standard NAPALM drivers return ip values as str while the
+                # enhanced Junos driver yields ipaddress objects; normalize once
+                # so the network membership test works for both shapes.
                 ip_interface_object = None
                 routing_instance = None
                 netbox_prefix_qs = Prefix.objects.none()
+                arp_ip = ipaddress.ip_address(str(arp_entry["ip"]))
                 for data in interface_ip_data.values():
                     routing_instance = data.get("netbox_vrf", False)
 
@@ -285,8 +289,8 @@ class NapalmCollector:
                         )
                         continue
 
-                    if arp_entry["ip"] in data["ip_interface_object"].network:
-                        ip_interface_object = ipaddress.ip_interface(f"{arp_entry['ip']}/{data['prefix_length']}")
+                    if arp_ip in data["ip_interface_object"].network:
+                        ip_interface_object = ipaddress.ip_interface(f"{arp_ip}/{data['prefix_length']}")
                         routing_instance = data.get("netbox_vrf")
                         netbox_prefix_qs = data.get("netbox_prefixes")
                         break
@@ -1882,6 +1886,12 @@ class NapalmCollector:
         )
 
         try:
+            # Resolve the collection method up front so an unknown collector
+            # type surfaces as NotImplementedError without hiding genuine
+            # AttributeErrors raised while a collector runs.
+            collect = getattr(self, self._collector_type, None)
+            if collect is None:
+                raise NotImplementedError(f"Collector type '{self._collector_type}' is not implemented.")
             for device in self._devices:
                 self._current_device = device
                 self._log_prefix = get_absolute_url_markdown(device, bold=True)
@@ -1909,12 +1919,9 @@ class NapalmCollector:
                             self._napalm_password,
                             optional_args=self._napalm_args,
                         ) as driver:
-                            # Lookup the collection method and call it
-                            getattr(self, self._collector_type)(driver)
+                            collect(driver)
                         connected = True
                         break
-                    except AttributeError as exc:
-                        raise NotImplementedError from exc
                     except ConnectionException as exc:
                         detail = exc.__cause__ or exc
                         self._log_warning(f"Connection failed via {label} IP `{ip}`: {detail}")

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -196,9 +196,7 @@ class NapalmCollector:
         instances = self._napalm_rpc(driver.get_network_instances, "network instances")
         if instances is None:
             instances = {}
-        return get_network_instances_by_interface(
-            resolve_napalm_network_instances(parse_network_instances(instances))
-        )
+        return get_network_instances_by_interface(resolve_napalm_network_instances(parse_network_instances(instances)))
 
     def _ip_neighbors(
         self,
@@ -333,7 +331,9 @@ class NapalmCollector:
                 ip_action = EntryActionChoices.ACTION_CONFIRMED if existing_ip else EntryActionChoices.ACTION_NEW
                 seen_ips.add(ip_cache_key)
 
-                vrf_name = str(routing_instance) if routing_instance else None
+                # Store the VRF name (never str(VRF), which appends the route
+                # distinguisher) so the applier's name lookup round-trips.
+                vrf_name = routing_instance.name if routing_instance else None
                 detected = {
                     "mac": arp_entry["mac"],
                     "ip": str(ip_interface_object),
@@ -446,7 +446,7 @@ class NapalmCollector:
                         detected_values={},
                         current_values={
                             "ip": str(ip_obj.address),
-                            "vrf": str(ip_obj.vrf) if ip_obj.vrf else None,
+                            "vrf": ip_obj.vrf.name if ip_obj.vrf else None,
                         },
                         object_instance=ip_obj,
                         object_repr=self._object_repr(ip_obj),

--- a/netbox_facts/napalm/junos.py
+++ b/netbox_facts/napalm/junos.py
@@ -1,14 +1,32 @@
 import re
 from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 
 import napalm.base.helpers
+from jnpr.junos.exception import ConnectError, RpcError
+from napalm.base.exceptions import CommandErrorException, ConnectionException
 from napalm.junos import JunOSDriver
 
 from .helpers import ip_object
 from .utils import junos_views
 
 __all__ = ("EnhancedJunOSDriver",)
+
+
+@contextmanager
+def _translate_pyez_errors():
+    """Translate PyEZ transport errors into their NAPALM equivalents.
+
+    The collector's RPC wrapper only degrades NAPALM exceptions into a
+    per-device failure; raw PyEZ errors would abort the whole run.
+    """
+    try:
+        yield
+    except ConnectError as exc:
+        raise ConnectionException(str(exc)) from exc
+    except RpcError as exc:
+        raise CommandErrorException(str(exc)) from exc
 
 
 def _module_to_dict(module, parent_name=None):
@@ -38,7 +56,8 @@ class EnhancedJunOSDriver(JunOSDriver):  # pylint: disable=abstract-method
             raise NotImplementedError(msg)
 
         arp_table_raw = junos_views.junos_arp_table(self.device)
-        arp_table_raw.get()
+        with _translate_pyez_errors():
+            arp_table_raw.get()
         arp_table_items = arp_table_raw.items()
 
         for arp_table_entry in arp_table_items:
@@ -50,7 +69,8 @@ class EnhancedJunOSDriver(JunOSDriver):  # pylint: disable=abstract-method
     def get_ipv6_neighbors_table(self) -> Generator[dict[str, Any], None, None]:
         """Return the IPv6 neighbors table with the ip address object."""
         ipv6_neighbors_table_raw = junos_views.junos_ipv6_neighbors_table(self.device)
-        ipv6_neighbors_table_raw.get()
+        with _translate_pyez_errors():
+            ipv6_neighbors_table_raw.get()
         ipv6_neighbors_table_items = ipv6_neighbors_table_raw.items()
 
         for ipv6_table_entry in ipv6_neighbors_table_items:

--- a/netbox_facts/tests/test_arp_ndp_regressions.py
+++ b/netbox_facts/tests/test_arp_ndp_regressions.py
@@ -1,0 +1,118 @@
+"""Regression tests for ARP/NDP collector portability and VRF round-trip bugs."""
+
+import re
+
+from unittest.mock import MagicMock
+
+from dcim.models.device_components import Interface
+from django.test import TestCase
+from ipam.models.ip import IPAddress, Prefix
+
+from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.models.mac import MACAddress
+from netbox_facts.tests.test_helpers import CollectorTestMixin
+
+
+class ArpNdpCollectorTestMixin(CollectorTestMixin):
+    """Collector mixin with a permissive interface regex for ARP/NDP tests."""
+
+    def _make_collector(self, plan):
+        collector = super()._make_collector(plan)
+        collector._interfaces_re = re.compile(r".*")
+        return collector
+
+    @staticmethod
+    def _default_instance_for(interface_name):
+        """Standard-driver get_network_instances payload for the global table."""
+        return {
+            "default": {
+                "name": "default",
+                "type": "DEFAULT_INSTANCE",
+                "state": {"route_distinguisher": ""},
+                "interfaces": {"interface": {interface_name: {}}},
+            },
+        }
+
+
+class ArpStrIpPortabilityTest(ArpNdpCollectorTestMixin, TestCase):
+    """The ARP/NDP pipeline must accept the str ip values standard drivers return."""
+
+    def test_arp_processes_standard_driver_str_ip_table(self):
+        """Str-ip ARP rows from standard NAPALM drivers are processed, not fatal.
+
+        Regression test for issue #43: 'ip' values are plain strings on every
+        standard NAPALM driver, and the str-in-network membership test raised
+        AttributeError, aborting the whole run.
+        """
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-arp-str-ip",
+        )
+        device = self._create_device("arp-strip-dev1")
+        Interface.objects.create(device=device, name="Ethernet1", type="1000base-t")
+        Prefix.objects.create(prefix="10.1.0.0/24")
+        collector = self._make_collector(plan)
+        collector._current_device = device
+
+        driver = MagicMock()
+        driver.get_arp_table.return_value = [
+            {
+                "interface": "Ethernet1",
+                "mac": "AA:BB:CC:DD:EE:30",
+                "ip": "10.1.0.50",
+                "age": 12.0,
+            },
+        ]
+        driver.get_interfaces_ip.return_value = {
+            "Ethernet1": {"ipv4": {"10.1.0.1": {"prefix_length": 24}}},
+        }
+        driver.get_network_instances.return_value = self._default_instance_for("Ethernet1")
+
+        collector.arp(driver)
+
+        self.assertTrue(MACAddress.objects.filter(mac_address="AA:BB:CC:DD:EE:30").exists())
+        self.assertTrue(IPAddress.objects.filter(address="10.1.0.50/24").exists())
+
+
+class ExecuteDispatchTest(ArpNdpCollectorTestMixin, TestCase):
+    """execute() collector dispatch must not disguise collector-body errors."""
+
+    def test_unknown_collector_type_raises_not_implemented(self):
+        """An unknown collector type raises NotImplementedError (issue #43)."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-exec-unknown",
+        )
+        collector = self._make_collector(plan)
+        collector._collector_type = "no_such_collector"
+        collector._napalm_driver = MagicMock()
+        collector._devices = []
+
+        with self.assertRaises(NotImplementedError):
+            collector.execute()
+
+    def test_attribute_error_in_collector_body_propagates(self):
+        """AttributeError inside a collector body stays an AttributeError.
+
+        Regression test for issue #43: execute() converted every
+        AttributeError raised while a collector ran into a misleading
+        NotImplementedError.
+        """
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-exec-attr-error",
+        )
+        device = self._create_device("exec-attr-dev1")
+        iface = Interface.objects.create(device=device, name="mgmt0", type="1000base-t")
+        ip = IPAddress.objects.create(address="192.0.2.10/24", assigned_object=iface)
+        device.primary_ip4 = ip
+        device.save()
+        device.refresh_from_db()
+
+        collector = self._make_collector(plan)
+        collector._devices = [device]
+        collector._napalm_driver = MagicMock()
+        collector.arp = MagicMock(side_effect=AttributeError("real attribute bug"))
+
+        with self.assertRaises(AttributeError):
+            collector.execute()

--- a/netbox_facts/tests/test_arp_ndp_regressions.py
+++ b/netbox_facts/tests/test_arp_ndp_regressions.py
@@ -156,6 +156,47 @@ class EnhancedJunosRpcTranslationTest(TestCase):
                 list(driver.get_ipv6_neighbors_table())
 
 
+class NetworkInstancesUnsupportedTest(ArpNdpCollectorTestMixin, TestCase):
+    """Drivers without get_network_instances must not abort ARP collection."""
+
+    def test_arp_proceeds_when_get_network_instances_unsupported(self):
+        """arp() completes without VRF context when get_network_instances raises.
+
+        Regression test for issue #45: NAPALM's iosxr drivers do not
+        implement get_network_instances, and the unguarded call let the
+        base class NotImplementedError abort the whole run even though the
+        getters ARP actually needs are implemented.
+        """
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-arp-no-netinst",
+        )
+        device = self._create_device("arp-noinst-dev1")
+        Interface.objects.create(device=device, name="GigabitEthernet0/0/0/1", type="1000base-t")
+        Prefix.objects.create(prefix="10.3.0.0/24")
+        collector = self._make_collector(plan)
+        collector._current_device = device
+
+        driver = MagicMock()
+        driver.get_network_instances.side_effect = NotImplementedError
+        driver.get_arp_table.return_value = [
+            {
+                "interface": "GigabitEthernet0/0/0/1",
+                "mac": "AA:BB:CC:DD:EE:40",
+                "ip": "10.3.0.50",
+                "age": 5.0,
+            },
+        ]
+        driver.get_interfaces_ip.return_value = {
+            "GigabitEthernet0/0/0/1": {"ipv4": {"10.3.0.1": {"prefix_length": 24}}},
+        }
+
+        collector.arp(driver)
+
+        self.assertTrue(MACAddress.objects.filter(mac_address="AA:BB:CC:DD:EE:40").exists())
+        self.assertTrue(IPAddress.objects.filter(address="10.3.0.50/24").exists())
+
+
 class ExecuteDispatchTest(ArpNdpCollectorTestMixin, TestCase):
     """execute() collector dispatch must not disguise collector-body errors."""
 

--- a/netbox_facts/tests/test_arp_ndp_regressions.py
+++ b/netbox_facts/tests/test_arp_ndp_regressions.py
@@ -2,14 +2,18 @@
 
 import re
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from dcim.models.device_components import Interface
 from django.test import TestCase
 from ipam.models.ip import IPAddress, Prefix
+from jnpr.junos.exception import ConnectError, RpcError
+from napalm.base.exceptions import CommandErrorException, ConnectionException
 
 from netbox_facts.choices import CollectionTypeChoices
 from netbox_facts.models.mac import MACAddress
+from netbox_facts.napalm.junos import EnhancedJunOSDriver
+from netbox_facts.napalm.utils import junos_views
 from netbox_facts.tests.test_helpers import CollectorTestMixin
 
 
@@ -72,6 +76,84 @@ class ArpStrIpPortabilityTest(ArpNdpCollectorTestMixin, TestCase):
 
         self.assertTrue(MACAddress.objects.filter(mac_address="AA:BB:CC:DD:EE:30").exists())
         self.assertTrue(IPAddress.objects.filter(address="10.1.0.50/24").exists())
+
+
+class GeneratorRpcErrorHandlingTest(ArpNdpCollectorTestMixin, TestCase):
+    """RPC errors surfacing when a generator getter is iterated must not escape."""
+
+    @staticmethod
+    def _failing_table(exc):
+        raise exc
+        yield  # unreachable; makes this function a generator function
+
+    def _driver_with_failing_table(self, getter_name):
+        driver = MagicMock()
+        table = self._failing_table(CommandErrorException("RPC failed mid-stream"))
+        getattr(driver, getter_name).return_value = table
+        driver.get_network_instances.return_value = {}
+        driver.get_interfaces_ip.return_value = {}
+        return driver
+
+    def test_arp_generator_rpc_error_is_logged_and_skipped(self):
+        """An RPC error at first iteration of the ARP table skips the device.
+
+        Regression test for issue #44: generator getters defer the RPC past
+        _napalm_rpc, so iteration-time errors escaped arp() and aborted the
+        entire multi-device run.
+        """
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-arp-gen-error",
+        )
+        collector = self._make_collector(plan)
+        collector._current_device = self._create_device("arp-gen-dev1")
+        driver = self._driver_with_failing_table("get_arp_table")
+
+        with patch.object(collector, "_log_failure") as log_failure:
+            collector.arp(driver)
+
+        log_failure.assert_called()
+        self.assertEqual(MACAddress.objects.count(), 0)
+
+    def test_ndp_generator_rpc_error_is_logged_and_skipped(self):
+        """An RPC error at first iteration of the NDP table skips the device (issue #44)."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_NDP,
+            name="Plan-ndp-gen-error",
+        )
+        collector = self._make_collector(plan)
+        collector._current_device = self._create_device("ndp-gen-dev1")
+        driver = self._driver_with_failing_table("get_ipv6_neighbors_table")
+
+        with patch.object(collector, "_log_failure") as log_failure:
+            collector.ndp(driver)
+
+        log_failure.assert_called()
+        self.assertEqual(MACAddress.objects.count(), 0)
+
+
+class EnhancedJunosRpcTranslationTest(TestCase):
+    """EnhancedJunOSDriver getters translate PyEZ errors to NAPALM exceptions."""
+
+    @staticmethod
+    def _make_driver():
+        return EnhancedJunOSDriver("192.0.2.1", "user", "secret")
+
+    def test_get_arp_table_translates_rpc_error(self):
+        """A PyEZ RpcError during the ARP RPC becomes CommandErrorException (issue #44)."""
+        driver = self._make_driver()
+        with patch.object(junos_views, "junos_arp_table") as table_cls:
+            table_cls.return_value.get.side_effect = RpcError()
+            with self.assertRaises(CommandErrorException):
+                list(driver.get_arp_table())
+
+    def test_get_ipv6_neighbors_table_translates_connect_error(self):
+        """A PyEZ ConnectError during the NDP RPC becomes ConnectionException (issue #44)."""
+        driver = self._make_driver()
+        with patch.object(junos_views, "junos_ipv6_neighbors_table") as table_cls:
+            table_cls.return_value.get.side_effect = ConnectError(MagicMock())
+            with self.assertRaises(ConnectionException):
+                list(driver.get_ipv6_neighbors_table())
 
 
 class ExecuteDispatchTest(ArpNdpCollectorTestMixin, TestCase):

--- a/netbox_facts/tests/test_arp_ndp_regressions.py
+++ b/netbox_facts/tests/test_arp_ndp_regressions.py
@@ -1,16 +1,19 @@
 """Regression tests for ARP/NDP collector portability and VRF round-trip bugs."""
 
 import re
-
 from unittest.mock import MagicMock, patch
 
 from dcim.models.device_components import Interface
 from django.test import TestCase
 from ipam.models.ip import IPAddress, Prefix
+from ipam.models.vrfs import VRF
 from jnpr.junos.exception import ConnectError, RpcError
 from napalm.base.exceptions import CommandErrorException, ConnectionException
 
-from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices
+from netbox_facts.constants import AUTO_D_TAG
+from netbox_facts.helpers.netbox import resolve_vrf
+from netbox_facts.models.facts_report import FactsReport
 from netbox_facts.models.mac import MACAddress
 from netbox_facts.napalm.junos import EnhancedJunOSDriver
 from netbox_facts.napalm.utils import junos_views
@@ -195,6 +198,105 @@ class NetworkInstancesUnsupportedTest(ArpNdpCollectorTestMixin, TestCase):
 
         self.assertTrue(MACAddress.objects.filter(mac_address="AA:BB:CC:DD:EE:40").exists())
         self.assertTrue(IPAddress.objects.filter(address="10.3.0.50/24").exists())
+
+
+class VrfNameRoundTripTest(ArpNdpCollectorTestMixin, TestCase):
+    """Recorded VRF values must round-trip through resolve_vrf on apply."""
+
+    @staticmethod
+    def _l3vrf_instance_for(vrf, interface_name):
+        return {
+            vrf.name: {
+                "name": vrf.name,
+                "type": "L3VRF",
+                "state": {"route_distinguisher": str(vrf.rd)},
+                "interfaces": {"interface": {interface_name: {}}},
+            },
+        }
+
+    def test_detected_vrf_is_name_when_vrf_has_rd(self):
+        """Detected entries store the VRF name, not str(VRF).
+
+        Regression test for issue #52: str(VRF) is 'name (rd)' when a route
+        distinguisher is set, so the applier's resolve_vrf lookup failed on
+        detect-then-apply and the IP landed in the global table.
+        """
+        vrf = VRF.objects.create(name="VRF_RD", rd="65000:1")
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-arp-vrf-rd",
+            detect_only=True,
+        )
+        device = self._create_device("arp-vrfrd-dev1")
+        Interface.objects.create(device=device, name="Ethernet5", type="1000base-t")
+        Prefix.objects.create(prefix="10.2.0.0/24", vrf=vrf)
+        report = FactsReport.objects.create(collection_plan=plan)
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = report
+
+        driver = MagicMock()
+        driver.get_arp_table.return_value = [
+            {
+                "interface": "Ethernet5",
+                "mac": "AA:BB:CC:DD:EE:50",
+                "ip": "10.2.0.50",
+                "age": 3.0,
+            },
+        ]
+        driver.get_interfaces_ip.return_value = {
+            "Ethernet5": {"ipv4": {"10.2.0.1": {"prefix_length": 24}}},
+        }
+        driver.get_network_instances.return_value = self._l3vrf_instance_for(vrf, "Ethernet5")
+
+        collector.arp(driver)
+
+        entry = report.entries.first()
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.detected_values["vrf"], "VRF_RD")
+        self.assertEqual(resolve_vrf(entry.detected_values["vrf"]), vrf)
+
+    def test_stale_current_values_vrf_is_name_when_vrf_has_rd(self):
+        """Stale entries store the VRF name in current_values, not str(VRF) (issue #52)."""
+        vrf = VRF.objects.create(name="VRF_RD2", rd="65000:2")
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_ARP,
+            name="Plan-arp-vrf-stale",
+            detect_only=True,
+        )
+        device = self._create_device("arp-vrfstale-dev1")
+        iface = Interface.objects.create(device=device, name="Ethernet6", type="1000base-t")
+        Prefix.objects.create(prefix="10.4.0.0/24", vrf=vrf)
+
+        stale_mac = MACAddress.objects.create(mac_address="AA:BB:CC:DD:EE:60")
+        stale_mac.interfaces.add(iface)
+        stale_ip = IPAddress.objects.create(address="10.4.0.99/24", vrf=vrf)
+        stale_ip.tags.add(AUTO_D_TAG)
+        stale_mac.ip_addresses.add(stale_ip)
+
+        report = FactsReport.objects.create(collection_plan=plan)
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = report
+
+        driver = MagicMock()
+        driver.get_arp_table.return_value = [
+            {
+                "interface": "Ethernet6",
+                "mac": "AA:BB:CC:DD:EE:61",
+                "ip": "10.4.0.50",
+                "age": 3.0,
+            },
+        ]
+        driver.get_interfaces_ip.return_value = {
+            "Ethernet6": {"ipv4": {"10.4.0.1": {"prefix_length": 24}}},
+        }
+        driver.get_network_instances.return_value = self._l3vrf_instance_for(vrf, "Ethernet6")
+
+        collector.arp(driver)
+
+        stale_entry = report.entries.get(action=EntryActionChoices.ACTION_STALE)
+        self.assertEqual(stale_entry.current_values["vrf"], "VRF_RD2")
 
 
 class ExecuteDispatchTest(ArpNdpCollectorTestMixin, TestCase):


### PR DESCRIPTION
## Summary
- Makes ARP/NDP collection work on standard NAPALM drivers and stops single-device RPC errors from aborting whole multi-device runs.
- Fixes the detect-then-apply VRF round-trip so IPs land in the right VRF when it carries a route distinguisher.

## Changes
- netbox_facts/helpers/collector.py: neighbor IPs normalized before network-membership tests; collector dispatch resolved up front so real AttributeErrors propagate (no more NotImplementedError disguise); _napalm_rpc materializes generator getters inside its error handling; _get_network_instances degrades to an empty mapping on unsupported drivers; VRF recorded by name in detected/current values.
- netbox_facts/napalm/junos.py: _translate_pyez_errors context manager maps PyEZ ConnectError/RpcError to NAPALM exceptions in both enhanced getters.
- netbox_facts/tests/test_arp_ndp_regressions.py: 10 regression tests, each red on the pre-fix code.
- CHANGELOG.md: entries under Unreleased / Fixed.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (full plugin suite: 292 passed, 18 pre-existing skips)
- [x] New/changed behavior covered by tests (diff-cover: 100% of 177 changed lines)
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Fixes #43
Fixes #44
Fixes #45
Fixes #52
