### PR TITLE
fix(inventory): stop destructive module sweeps and detect type swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
   matrix pinned to the newest release of each supported minor. The
   README compatibility matrix now lists NetBox 4.5.x and 4.6.x.
 
+### Fixed
+
+- The stale-module sweep no longer deletes or STALE-flags Modules for hardware that is still installed when the ModuleBay or ModuleType of a reported chassis component cannot be resolved; an unresolved bay now suppresses the sweep for the whole device with a warning. (#50)
+- Swapping the hardware in a module bay for a different part is now detected as CHANGED (even with an unchanged serial), reported with the current module type, and applied by replacing the Module with one of the new ModuleType instead of only updating the serial. (#51)
+
 ## [0.1.1] - 2026-05-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
 - RPC errors raised while iterating the enhanced Junos generator getters are now translated to NAPALM exceptions and handled per device instead of aborting the whole run (#44).
 - Drivers without get_network_instances (e.g. iosxr) no longer abort ARP/interface collection; VRF context degrades to an empty mapping with an informational log (#45).
 - ARP/NDP report entries now record the VRF name instead of str(VRF), so detect-then-apply resolves the VRF instead of silently writing IPs into the global table when the VRF has a route distinguisher (#52).
+- The stale-module sweep no longer deletes or STALE-flags Modules for hardware that is still installed when the ModuleBay or ModuleType of a reported chassis component cannot be resolved; an unresolved bay now suppresses the sweep for the whole device with a warning. (#50)
+- Swapping the hardware in a module bay for a different part is now detected as CHANGED (even with an unchanged serial), reported with the current module type, and applied by replacing the Module with one of the new ModuleType instead of only updating the serial. (#51)
 
 ### Added
 
@@ -41,11 +43,6 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
   and 4.6.10, previously 4.5.8 and 4.5.10), with Renovate keeping the
   matrix pinned to the newest release of each supported minor. The
   README compatibility matrix now lists NetBox 4.5.x and 4.6.x.
-
-### Fixed
-
-- The stale-module sweep no longer deletes or STALE-flags Modules for hardware that is still installed when the ModuleBay or ModuleType of a reported chassis component cannot be resolved; an unresolved bay now suppresses the sweep for the whole device with a warning. (#50)
-- Swapping the hardware in a module bay for a different part is now detected as CHANGED (even with an unchanged serial), reported with the current module type, and applied by replacing the Module with one of the new ModuleType instead of only updating the serial. (#51)
 
 ## [0.1.1] - 2026-05-01
 

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -276,11 +276,17 @@ def _apply_module(entry):
         mod = create_module(entry.device, bay, mod_type, serial)
     elif entry.action == EntryActionChoices.ACTION_CHANGED:
         mod = getattr(bay, "installed_module", None)
-        if mod is not None:
+        if mod is None:
+            raise ValueError(f"No installed module in bay {bay.name} to update")
+        if mod.module_type_id != mod_type.pk:
+            # A different part now occupies the bay. Module components derive
+            # from the type, so replace the Module outright rather than
+            # mutating module_type in place.
+            mod.delete()
+            mod = create_module(entry.device, bay, mod_type, serial)
+        else:
             mod.serial = serial
             mod.save(update_fields=["serial"])
-        else:
-            raise ValueError(f"No installed module in bay {bay.name} to update")
 
     _set_entry_object(entry, mod)
 

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -28,6 +28,7 @@ from netbox_facts.helpers.netbox import (
     get_or_create_mac,
     resolve_device_by_name,
     resolve_vrf,
+    update_or_replace_module,
 )
 from netbox_facts.models.mac import MACAddress
 
@@ -278,15 +279,7 @@ def _apply_module(entry):
         mod = getattr(bay, "installed_module", None)
         if mod is None:
             raise ValueError(f"No installed module in bay {bay.name} to update")
-        if mod.module_type_id != mod_type.pk:
-            # A different part now occupies the bay. Module components derive
-            # from the type, so replace the Module outright rather than
-            # mutating module_type in place.
-            mod.delete()
-            mod = create_module(entry.device, bay, mod_type, serial)
-        else:
-            mod.serial = serial
-            mod.save(update_fields=["serial"])
+        mod = update_or_replace_module(entry.device, bay, mod, mod_type, serial)
 
     _set_entry_object(entry, mod)
 

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -780,12 +780,12 @@ class NapalmCollector:
         if installed is None:
             action = EntryActionChoices.ACTION_NEW
             current = {}
-        elif installed.serial == serial:
+        elif installed.serial == serial and installed.module_type_id == module_type.pk:
             action = EntryActionChoices.ACTION_CONFIRMED
-            current = {"serial": installed.serial}
+            current = {"serial": installed.serial, "module_type_id": installed.module_type_id}
         else:
             action = EntryActionChoices.ACTION_CHANGED
-            current = {"serial": installed.serial}
+            current = {"serial": installed.serial, "module_type_id": installed.module_type_id}
 
         mod_detected = {
             "name": name,
@@ -814,8 +814,15 @@ class NapalmCollector:
                 modules_by_name[name] = mod_obj
                 self._mark_entry_applied(mod_entry, mod_obj, object_repr=self._object_repr(mod_obj))
             elif action == EntryActionChoices.ACTION_CHANGED:
-                installed.serial = serial
-                installed.save(update_fields=["serial"])
+                if installed.module_type_id != module_type.pk:
+                    # A different part now occupies the bay. Module components
+                    # derive from the type, so replace the Module outright
+                    # rather than mutating module_type in place.
+                    installed.delete()
+                    installed = create_module(device, bay, module_type, serial)
+                else:
+                    installed.serial = serial
+                    installed.save(update_fields=["serial"])
                 modules_by_name[name] = installed
                 self._mark_entry_applied(mod_entry, installed, object_repr=self._object_repr(installed))
             else:

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -54,6 +54,7 @@ from netbox_facts.helpers.netbox import (
     resolve_napalm_interfaces_ip_addresses,
     resolve_napalm_network_instances,
     resolve_vrf,
+    update_or_replace_module,
 )
 from netbox_facts.models.mac import MACAddress
 from netbox_facts.napalm.junos import EnhancedJunOSDriver
@@ -814,15 +815,7 @@ class NapalmCollector:
                 modules_by_name[name] = mod_obj
                 self._mark_entry_applied(mod_entry, mod_obj, object_repr=self._object_repr(mod_obj))
             elif action == EntryActionChoices.ACTION_CHANGED:
-                if installed.module_type_id != module_type.pk:
-                    # A different part now occupies the bay. Module components
-                    # derive from the type, so replace the Module outright
-                    # rather than mutating module_type in place.
-                    installed.delete()
-                    installed = create_module(device, bay, module_type, serial)
-                else:
-                    installed.serial = serial
-                    installed.save(update_fields=["serial"])
+                installed = update_or_replace_module(device, bay, installed, module_type, serial)
                 modules_by_name[name] = installed
                 self._mark_entry_applied(mod_entry, installed, object_repr=self._object_repr(installed))
             else:

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -543,6 +543,9 @@ class NapalmCollector:
         # Track Modules by name for sub-module parent bay lookups
         modules_by_name = {}
         seen_module_bay_ids = set()
+        # Components whose ModuleBay could not be resolved; any such
+        # component makes the stale-module sweep unsafe for this device.
+        unresolved_bay_components = []
 
         for mod in modules:
             name = mod["name"]
@@ -629,7 +632,7 @@ class NapalmCollector:
                     self._mark_entry_applied(entry, existing)
 
             # --- Module creation logic ---
-            self._collect_chassis_module(
+            bay_resolved = self._collect_chassis_module(
                 device,
                 manufacturer,
                 name,
@@ -641,6 +644,8 @@ class NapalmCollector:
                 modules_by_name,
                 seen_module_bay_ids,
             )
+            if not bay_resolved:
+                unresolved_bay_components.append(component_name)
 
         # Detect stale discovered items (hardware no longer present)
         stale_items = InventoryItem.objects.filter(
@@ -667,7 +672,17 @@ class NapalmCollector:
                 stale_item.delete()
                 self._mark_entry_applied(stale_entry, device)
 
-        # Detect stale auto-discovered Modules
+        # Detect stale auto-discovered Modules. When any reported component's
+        # bay could not be resolved, the set of seen bays is incomplete and a
+        # sweep could delete Modules for hardware that is still installed, so
+        # skip it entirely for this device.
+        if unresolved_bay_components:
+            self._log_warning(
+                "Skipping stale module detection: could not resolve module bays for "
+                + ", ".join(unresolved_bay_components)
+            )
+            return
+
         stale_modules = Module.objects.filter(
             device=device,
             tags__name=AUTO_D_TAG,
@@ -709,6 +724,10 @@ class NapalmCollector:
 
         Called after the InventoryItem entry for each module. Only creates a
         Module when a matching ModuleBay and ModuleType exist in NetBox.
+
+        Returns True when the ModuleBay was resolved (even if the ModuleType
+        was not), False when no ModuleBay could be found for the component.
+        The caller uses this to decide whether the stale-module sweep is safe.
         """
         # Resolve parent Module for sub-module bay lookups
         parent_module = None
@@ -733,7 +752,12 @@ class NapalmCollector:
 
         if bay is None:
             self._log_warning(f"No ModuleBay found for {component_name}")
-            return
+            return False
+
+        # The hardware is demonstrably present in this bay; record it as seen
+        # before any further resolution so a lookup failure below can never
+        # make the stale-module sweep treat the bay as empty.
+        seen_module_bay_ids.add(bay.pk)
 
         # Find ModuleType — part_number takes precedence over model
         module_type = ModuleType.objects.filter(
@@ -748,9 +772,7 @@ class NapalmCollector:
 
         if module_type is None:
             self._log_warning(f"No ModuleType found for part {part_id}")
-            return
-
-        seen_module_bay_ids.add(bay.pk)
+            return True
 
         # Check existing module in bay
         installed = getattr(bay, "installed_module", None)
@@ -803,6 +825,8 @@ class NapalmCollector:
             # Track for stale detection even in detect-only mode
             if installed is not None:
                 modules_by_name[name] = installed
+
+        return True
 
     def _get_or_create_interface(self, device, name, iface_data=None):
         """Look up an interface on a device, creating it if missing.

--- a/netbox_facts/helpers/netbox.py
+++ b/netbox_facts/helpers/netbox.py
@@ -250,3 +250,20 @@ def create_module(device, module_bay, module_type, serial):
     mod.save()
     mod.tags.add(AUTO_D_TAG)
     return mod
+
+
+def update_or_replace_module(device, bay, installed, module_type, serial):
+    """Update an installed Module's serial, or replace it on a type change.
+
+    When a different part now occupies the bay, the Module's components
+    derive from the type and would be wrong, so the Module is replaced
+    outright via create_module rather than mutating module_type in place.
+    A same-type change only updates the serial. Returns the resulting
+    Module.
+    """
+    if installed.module_type_id != module_type.pk:
+        installed.delete()
+        return create_module(device, bay, module_type, serial)
+    installed.serial = serial
+    installed.save(update_fields=["serial"])
+    return installed

--- a/netbox_facts/tests/test_inventory_regressions.py
+++ b/netbox_facts/tests/test_inventory_regressions.py
@@ -1,0 +1,151 @@
+"""Regression tests for chassis inventory Module reconciliation defects."""
+
+from unittest.mock import MagicMock
+
+from dcim.models.device_components import ModuleBay
+from dcim.models.modules import Module, ModuleType
+from django.test import TestCase
+from napalm.base.exceptions import ConnectionException
+
+from netbox_facts.choices import EntryActionChoices
+from netbox_facts.constants import AUTO_D_TAG
+from netbox_facts.models.facts_report import FactsReport
+from netbox_facts.tests.test_helpers import CollectorTestMixin
+
+
+class ChassisModuleSweepRegressionTest(CollectorTestMixin, TestCase):
+    """Regression tests for the stale-module sweep (issue #50).
+
+    A failed ModuleBay or ModuleType resolution for a reported chassis
+    module must never translate into the module being flagged stale or
+    deleted -- the hardware is demonstrably still present.
+    """
+
+    def _make_chassis_driver(self, modules):
+        """Create a mock driver whose get_chassis_inventory returns modules."""
+        driver = MagicMock()
+        driver.get_facts.return_value = {
+            "serial_number": "CHASSIS_SN",
+            "os_version": "21.2R3",
+            "hostname": "router1",
+            "fqdn": "router1.example.com",
+        }
+        driver.get_chassis_inventory.return_value = iter(modules)
+        return driver
+
+    def _install_module(self, device, bay_name, part_number, serial):
+        """Create a ModuleBay holding an AUTO_D-tagged Module of a new type."""
+        bay = ModuleBay.objects.create(device=device, name=bay_name)
+        mod_type = ModuleType.objects.create(
+            manufacturer=self.manufacturer,
+            model=f"MOD-{part_number}",
+            part_number=part_number,
+        )
+        mod = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=mod_type,
+            serial=serial,
+        )
+        mod.tags.add(AUTO_D_TAG)
+        return bay, mod_type, mod
+
+    def test_present_module_with_unresolved_type_not_swept(self):
+        """Issue #50: a present module whose ModuleType lookup fails must not
+        be deleted or flagged STALE by the stale-module sweep."""
+        plan = self._create_plan()
+        device = self._create_device("regr-mod-type", serial="CHASSIS_SN")
+        bay, _mod_type, mod = self._install_module(device, "FPC 0", "750-11111", "FPC0_SN")
+
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+        collector._log_warning = MagicMock()
+
+        # Same hardware, but the part_id no longer matches any ModuleType
+        # (e.g. the ModuleType was renamed in NetBox).
+        driver = self._make_chassis_driver(
+            [
+                {
+                    "name": "FPC 0",
+                    "component_name": "FPC 0",
+                    "parent_name": None,
+                    "serial": "FPC0_SN",
+                    "part_id": "750-RENAMED",
+                    "description": "MPC 4e 3D",
+                },
+            ]
+        )
+
+        collector.inventory(driver)
+
+        self.assertTrue(Module.objects.filter(pk=mod.pk).exists())
+        stale_entries = collector._report.entries.filter(
+            action=EntryActionChoices.ACTION_STALE,
+            object_repr__startswith="Module ",
+        )
+        self.assertEqual(stale_entries.count(), 0)
+        warnings = [call.args[0] for call in collector._log_warning.call_args_list]
+        self.assertTrue(any("750-RENAMED" in msg for msg in warnings))
+
+    def test_sweep_suppressed_when_bay_unresolved(self):
+        """Issue #50: when a reported module's bay cannot be resolved, the
+        stale-module sweep must be suppressed for the whole device."""
+        plan = self._create_plan()
+        device = self._create_device("regr-mod-bay", serial="CHASSIS_SN")
+        bay, mod_type, mod = self._install_module(device, "FPC 0", "750-11111", "FPC0_SN")
+
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+        collector._log_warning = MagicMock()
+
+        # The device reports a module in a bay NetBox does not model; the
+        # module in FPC 0 is not reported (e.g. renamed components), so a
+        # sweep keyed on seen bays would wrongly delete it.
+        driver = self._make_chassis_driver(
+            [
+                {
+                    "name": "FPC 5",
+                    "component_name": "FPC 5",
+                    "parent_name": None,
+                    "serial": "FPC5_SN",
+                    "part_id": "750-11111",
+                    "description": "MPC 4e 3D",
+                },
+            ]
+        )
+
+        collector.inventory(driver)
+
+        self.assertTrue(Module.objects.filter(pk=mod.pk).exists())
+        stale_entries = collector._report.entries.filter(
+            action=EntryActionChoices.ACTION_STALE,
+            object_repr__startswith="Module ",
+        )
+        self.assertEqual(stale_entries.count(), 0)
+        warnings = [call.args[0] for call in collector._log_warning.call_args_list]
+        self.assertTrue(any("FPC 5" in msg and "stale" in msg.lower() for msg in warnings))
+
+    def test_rpc_failure_does_not_reach_module_sweep(self):
+        """Issue #50: a failed get_chassis_inventory RPC must leave existing
+        auto-discovered Modules untouched."""
+        plan = self._create_plan()
+        device = self._create_device("regr-mod-rpc", serial="CHASSIS_SN")
+        _bay, _mod_type, mod = self._install_module(device, "FPC 0", "750-11111", "FPC0_SN")
+
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+
+        driver = self._make_chassis_driver([])
+        driver.get_chassis_inventory.side_effect = ConnectionException("unreachable")
+
+        collector.inventory(driver)
+
+        self.assertTrue(Module.objects.filter(pk=mod.pk).exists())
+        stale_entries = collector._report.entries.filter(
+            action=EntryActionChoices.ACTION_STALE,
+            object_repr__startswith="Module ",
+        )
+        self.assertEqual(stale_entries.count(), 0)

--- a/netbox_facts/tests/test_inventory_regressions.py
+++ b/netbox_facts/tests/test_inventory_regressions.py
@@ -7,19 +7,16 @@ from dcim.models.modules import Module, ModuleType
 from django.test import TestCase
 from napalm.base.exceptions import ConnectionException
 
-from netbox_facts.choices import EntryActionChoices
+from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices
 from netbox_facts.constants import AUTO_D_TAG
-from netbox_facts.models.facts_report import FactsReport
+from netbox_facts.helpers.applier import apply_entries
+from netbox_facts.models.facts_report import FactsReport, FactsReportEntry
+from netbox_facts.tests.test_applier import ApplierTestMixin
 from netbox_facts.tests.test_helpers import CollectorTestMixin
 
 
-class ChassisModuleSweepRegressionTest(CollectorTestMixin, TestCase):
-    """Regression tests for the stale-module sweep (issue #50).
-
-    A failed ModuleBay or ModuleType resolution for a reported chassis
-    module must never translate into the module being flagged stale or
-    deleted -- the hardware is demonstrably still present.
-    """
+class ChassisFixtureMixin:
+    """Shared chassis-inventory fixtures for the regression tests below."""
 
     def _make_chassis_driver(self, modules):
         """Create a mock driver whose get_chassis_inventory returns modules."""
@@ -49,6 +46,15 @@ class ChassisModuleSweepRegressionTest(CollectorTestMixin, TestCase):
         )
         mod.tags.add(AUTO_D_TAG)
         return bay, mod_type, mod
+
+
+class ChassisModuleSweepRegressionTest(ChassisFixtureMixin, CollectorTestMixin, TestCase):
+    """Regression tests for the stale-module sweep (issue #50).
+
+    A failed ModuleBay or ModuleType resolution for a reported chassis
+    module must never translate into the module being flagged stale or
+    deleted -- the hardware is demonstrably still present.
+    """
 
     def test_present_module_with_unresolved_type_not_swept(self):
         """Issue #50: a present module whose ModuleType lookup fails must not
@@ -149,3 +155,170 @@ class ChassisModuleSweepRegressionTest(CollectorTestMixin, TestCase):
             object_repr__startswith="Module ",
         )
         self.assertEqual(stale_entries.count(), 0)
+
+
+class ChassisModuleTypeSwapRegressionTest(ChassisFixtureMixin, CollectorTestMixin, TestCase):
+    """Regression tests for module type swaps in a bay (issue #51).
+
+    Replacing the hardware in a bay with a different part must be detected
+    as CHANGED (even when the serial is unchanged), reported with the
+    current module type, and applied by replacing the Module's type.
+    """
+
+    def test_type_swap_detected_as_changed_and_applied(self):
+        """Issue #51: a different part in the bay must yield CHANGED with the
+        old module_type in current_values, and apply the new ModuleType."""
+        plan = self._create_plan()
+        device = self._create_device("regr-swap-1", serial="CHASSIS_SN")
+        bay, old_type, _mod = self._install_module(device, "FPC 0", "750-11111", "OLD_SN")
+        new_type = ModuleType.objects.create(
+            manufacturer=self.manufacturer,
+            model="MOD-750-22222",
+            part_number="750-22222",
+        )
+
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+
+        driver = self._make_chassis_driver(
+            [
+                {
+                    "name": "FPC 0",
+                    "component_name": "FPC 0",
+                    "parent_name": None,
+                    "serial": "NEW_SN",
+                    "part_id": "750-22222",
+                    "description": "Replacement card",
+                },
+            ]
+        )
+
+        collector.inventory(driver)
+
+        changed_entries = collector._report.entries.filter(
+            action=EntryActionChoices.ACTION_CHANGED,
+            object_repr__startswith="Module ",
+        )
+        self.assertEqual(changed_entries.count(), 1)
+        entry = changed_entries.first()
+        self.assertEqual(entry.current_values.get("module_type_id"), old_type.pk)
+
+        installed = Module.objects.get(device=device, module_bay=bay)
+        self.assertEqual(installed.module_type, new_type)
+        self.assertEqual(installed.serial, "NEW_SN")
+
+    def test_same_serial_type_swap_detected_as_changed(self):
+        """Issue #51: a different part reporting the same serial must be
+        CHANGED, not silently CONFIRMED."""
+        plan = self._create_plan(detect_only=True)
+        device = self._create_device("regr-swap-2", serial="CHASSIS_SN")
+        _bay, old_type, _mod = self._install_module(device, "FPC 0", "750-11111", "SAME_SN")
+        ModuleType.objects.create(
+            manufacturer=self.manufacturer,
+            model="MOD-750-22222",
+            part_number="750-22222",
+        )
+
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+
+        driver = self._make_chassis_driver(
+            [
+                {
+                    "name": "FPC 0",
+                    "component_name": "FPC 0",
+                    "parent_name": None,
+                    "serial": "SAME_SN",
+                    "part_id": "750-22222",
+                    "description": "Replacement card",
+                },
+            ]
+        )
+
+        collector.inventory(driver)
+
+        changed_entries = collector._report.entries.filter(
+            action=EntryActionChoices.ACTION_CHANGED,
+            object_repr__startswith="Module ",
+        )
+        self.assertEqual(changed_entries.count(), 1)
+        self.assertEqual(changed_entries.first().current_values.get("module_type_id"), old_type.pk)
+        confirmed_entries = collector._report.entries.filter(
+            action=EntryActionChoices.ACTION_CONFIRMED,
+            object_repr__startswith="Module ",
+        )
+        self.assertEqual(confirmed_entries.count(), 0)
+
+    def test_serial_only_swap_preserves_module_identity(self):
+        """A same-type serial change must update the Module in place, not
+        replace it."""
+        plan = self._create_plan()
+        device = self._create_device("regr-swap-3", serial="CHASSIS_SN")
+        bay, mod_type, mod = self._install_module(device, "FPC 0", "750-11111", "OLD_SN")
+
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+
+        driver = self._make_chassis_driver(
+            [
+                {
+                    "name": "FPC 0",
+                    "component_name": "FPC 0",
+                    "parent_name": None,
+                    "serial": "NEW_SN",
+                    "part_id": "750-11111",
+                    "description": "Same card, RMA replacement",
+                },
+            ]
+        )
+
+        collector.inventory(driver)
+
+        installed = Module.objects.get(device=device, module_bay=bay)
+        self.assertEqual(installed.pk, mod.pk)
+        self.assertEqual(installed.module_type, mod_type)
+        self.assertEqual(installed.serial, "NEW_SN")
+
+
+class ApplyModuleTypeSwapRegressionTest(ChassisFixtureMixin, ApplierTestMixin, TestCase):
+    """Regression tests for applying a module type swap (issue #51)."""
+
+    def test_apply_changed_entry_replaces_module_type(self):
+        """Issue #51: applying a CHANGED Module entry with a new module_type
+        must leave the bay holding the new ModuleType."""
+        bay, old_type, _mod = self._install_module(self.device, "FPC 0", "750-11111", "OLD_SN")
+        new_type = ModuleType.objects.create(
+            manufacturer=self.manufacturer,
+            model="MOD-750-22222",
+            part_number="750-22222",
+        )
+
+        report = FactsReport.objects.create(collection_plan=self.plan)
+        entry = FactsReportEntry.objects.create(
+            report=report,
+            action=EntryActionChoices.ACTION_CHANGED,
+            collector_type=CollectionTypeChoices.TYPE_INVENTORY,
+            device=self.device,
+            object_repr="Module FPC 0",
+            detected_values={
+                "name": "FPC 0",
+                "component_name": "FPC 0",
+                "serial": "NEW_SN",
+                "part_id": "750-22222",
+                "module_bay_id": bay.pk,
+                "module_type_id": new_type.pk,
+            },
+            current_values={"serial": "OLD_SN", "module_type_id": old_type.pk},
+        )
+
+        applied, failed = apply_entries(report, [entry.pk])
+        self.assertEqual(applied, 1)
+        self.assertEqual(failed, 0)
+
+        installed = Module.objects.get(device=self.device, module_bay=bay)
+        self.assertEqual(installed.module_type, new_type)
+        self.assertEqual(installed.serial, "NEW_SN")
+        self.assertTrue(installed.tags.filter(name=AUTO_D_TAG).exists())


### PR DESCRIPTION
## Summary
- Stops the stale-module sweep from deleting hardware that is still installed when bay or ModuleType resolution fails.
- Detects module type swaps in a bay (including same-serial part swaps) and applies them by replacing the Module instead of writing the new serial onto the old part.

## Changes
- netbox_facts/helpers/collector.py: resolved bays are marked seen before ModuleType lookup; an unresolvable bay suppresses the device's stale-module sweep with a warning; module action classification and current_values include module_type_id.
- netbox_facts/helpers/applier.py: _apply_module replaces the Module on type change via the shared helper.
- netbox_facts/helpers/netbox.py: shared update_or_replace_module helper used by both paths.
- netbox_facts/tests/test_inventory_regressions.py: 7 regression tests, each red on the pre-fix code.
- CHANGELOG.md: entries under Unreleased / Fixed.

Scope note: InventoryItem reconciliation is intentionally untouched; its future is #122 (modules-first direction).

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (test_helpers.py 110 passed, test_applier.py 38 passed)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Fixes #50
Fixes #51
Refs #122
