### PR TITLE
fix(collector): honor detect-only and scope stale sweeps in interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
 
 ## [Unreleased]
 
+### Fixed
+
+- Detect-only interfaces runs no longer create Interface objects in NetBox; missing interfaces are recorded as pending report entries that the applier creates on apply. (#47)
+- The stale-IP sweep is skipped when IP collection fails and no longer covers interfaces excluded by `valid_interfaces_re` or skipped for unresolvable VRFs, so transient RPC errors and scope changes cannot mass-unassign still-configured addresses. (#49)
+- A changed hardware MAC no longer aborts the collection run with an IntegrityError; the previous MACAddress row releases the interface before the new row claims it, in both the collector and the applier. (#55)
+- Junos inet destinations abbreviated below three octets (such as `10/8` and `172.16/16`) keep their real prefix length instead of being recorded and created as /32 host routes. (#56)
+- The generic IP path skips addresses in a device VRF that has no NetBox counterpart, recording a pending missing-VRF entry instead of booking them into the global table or stealing existing global IPs. (#57)
+- Duplicate VRF names in NetBox no longer abort the entire collection run with MultipleObjectsReturned; the affected instance's IPs are skipped with a warning. (#46)
+
 ### Added
 
 - `FactsConfig` now declares `min_version = "4.5.0"` and

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -321,17 +321,25 @@ def _apply_interfaces_entry(entry, now):
 
 
 def _apply_interfaces_mac(entry, dv, now):
-    """Apply an interface MAC entry."""
+    """Apply an interface MAC entry, creating the interface if missing."""
     mac_addr = dv.get("mac_address", "")
     iface_name = dv.get("interface", "")
 
+    nb_iface = None
+    if iface_name:
+        nb_iface = get_or_create_interface(entry.device, iface_name)
+
     if not mac_addr:
+        # MAC-less interface entry (detect-only run against a missing
+        # interface, or a logical carrier): creating the interface is
+        # the whole change.
+        if nb_iface is not None:
+            _set_entry_object(entry, nb_iface)
         return
 
     netbox_mac, created = get_or_create_mac(mac_addr)
 
-    if iface_name:
-        nb_iface = get_or_create_interface(entry.device, iface_name)
+    if nb_iface is not None:
         # device_interface is one-to-one: release any other MAC row still
         # holding this interface (hardware MAC change) before claiming it,
         # or save() raises IntegrityError.

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -22,6 +22,7 @@ from netbox_facts.choices import (
 )
 from netbox_facts.constants import AUTO_D_TAG
 from netbox_facts.helpers.netbox import (
+    claim_device_interface,
     create_module,
     get_or_create_interface,
     get_or_create_ip,
@@ -340,11 +341,7 @@ def _apply_interfaces_mac(entry, dv, now):
     netbox_mac, created = get_or_create_mac(mac_addr)
 
     if nb_iface is not None:
-        # device_interface is one-to-one: release any other MAC row still
-        # holding this interface (hardware MAC change) before claiming it,
-        # or save() raises IntegrityError.
-        MACAddress.objects.filter(device_interface=nb_iface).exclude(pk=netbox_mac.pk).update(device_interface=None)
-        netbox_mac.device_interface = nb_iface
+        claim_device_interface(netbox_mac, nb_iface)
 
     netbox_mac.discovery_method = CollectionTypeChoices.TYPE_INTERFACES
     netbox_mac.last_seen = now

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -332,6 +332,10 @@ def _apply_interfaces_mac(entry, dv, now):
 
     if iface_name:
         nb_iface = get_or_create_interface(entry.device, iface_name)
+        # device_interface is one-to-one: release any other MAC row still
+        # holding this interface (hardware MAC change) before claiming it,
+        # or save() raises IntegrityError.
+        MACAddress.objects.filter(device_interface=nb_iface).exclude(pk=netbox_mac.pk).update(device_interface=None)
         netbox_mac.device_interface = nb_iface
 
     netbox_mac.discovery_method = CollectionTypeChoices.TYPE_INTERFACES

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -1135,8 +1135,29 @@ class NapalmCollector:
                 self._record_missing_interface(device, iface_name)
                 continue
 
-            # Resolve VRF from network instances
+            # Resolve VRF from network instances. An absent netbox_vrf key
+            # means the device VRF exists but could not be resolved in
+            # NetBox; treating it as the global table would misfile (or
+            # steal) addresses, so skip those IPs instead.
             ni_data = network_instances.get(iface_name, {})
+            if ni_data.get("netbox_vrf_duplicate"):
+                self._log_warning(
+                    duplicate_object_warning("VRF", ni_data.get("name", "")) + f" Skipping IPs on `{iface_name}`."
+                )
+                self._skipped_ip_ifaces.add(iface_name)
+                continue
+            if ni_data and "netbox_vrf" not in ni_data:
+                vrf_name = ni_data.get("name", "")
+                self._log_warning(f"VRF `{vrf_name}` not found in NetBox. Skipping IPs on `{iface_name}`.")
+                self._record_entry(
+                    action=EntryActionChoices.ACTION_NEW,
+                    collector_type=self._collector_type,
+                    device=device,
+                    detected_values={"name": vrf_name},
+                    object_repr=f"VRF {vrf_name}",
+                )
+                self._skipped_ip_ifaces.add(iface_name)
+                continue
             netbox_vrf = ni_data.get("netbox_vrf")
 
             for family_name, addresses in family_data.items():

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -103,6 +103,7 @@ class NapalmCollector:
         self._report: FactsReport | None = None
         self._detect_only: bool = getattr(plan, "detect_only", False)
         self._seen_ips: set = set()
+        self._missing_ifaces: set = set()
 
         # Get the NAPALM driver
         try:
@@ -828,10 +829,15 @@ class NapalmCollector:
         Uses detect_interface_type() to infer the type and optionally
         populates description/enabled/mtu from iface_data.
         Sub-interfaces (containing '.') get their parent set to the physical interface.
+
+        In detect-only mode nothing is created: a missing interface
+        returns None so the caller can record a pending entry instead.
         """
         try:
             return device.vc_interfaces().get(name=name)
         except Interface.DoesNotExist:
+            if not self._should_apply():
+                return None
             iface_type = detect_interface_type(name)
             kwargs = {"device": device, "name": name, "type": iface_type}
             if "." in name:
@@ -852,9 +858,28 @@ class NapalmCollector:
             self._log_success(f"Auto-created interface `{name}` (type={iface_type}) on {device}.")
             return nb_iface
 
+    def _record_missing_interface(self, device, name, detected_values=None):
+        """Record a pending NEW entry for an interface absent from NetBox.
+
+        Used in detect-only mode, where interfaces are never created; the
+        applier creates the interface when the entry is applied. Each
+        interface is recorded at most once per device run.
+        """
+        if name in self._missing_ifaces:
+            return
+        self._missing_ifaces.add(name)
+        self._record_entry(
+            action=EntryActionChoices.ACTION_NEW,
+            collector_type=self._collector_type,
+            device=device,
+            detected_values=detected_values or {"interface": name},
+            object_repr=f"Interface {name}",
+        )
+
     def interfaces(self, driver: NetworkDriver):
         """Collect interface data from a device using get_interfaces()."""
         self._seen_ips = set()
+        self._missing_ifaces = set()
         # Always fetch all interfaces and filter client-side with the Python
         # regex.  Passing the regex pattern to the Junos RPC as interface_name
         # causes mismatches because Junos treats '.' as a literal dot while
@@ -881,7 +906,6 @@ class NapalmCollector:
                 # avoids creating system pseudo-interfaces like .local.
                 if not iface_data.get("logical_interfaces"):
                     continue
-                nb_iface = self._get_or_create_interface(device, iface_name, iface_data)
                 detected = {
                     "interface": iface_name,
                     "mac_address": "",
@@ -890,6 +914,10 @@ class NapalmCollector:
                     "mtu": iface_data.get("mtu"),
                     "is_up": iface_data.get("is_up"),
                 }
+                nb_iface = self._get_or_create_interface(device, iface_name, iface_data)
+                if nb_iface is None:
+                    self._record_missing_interface(device, iface_name, detected)
+                    continue
                 self._record_entry(
                     action=EntryActionChoices.ACTION_CONFIRMED,
                     collector_type=self._collector_type,
@@ -900,8 +928,6 @@ class NapalmCollector:
                 )
                 continue
 
-            nb_iface = self._get_or_create_interface(device, iface_name, iface_data)
-
             detected = {
                 "interface": iface_name,
                 "mac_address": mac_addr,
@@ -910,6 +936,11 @@ class NapalmCollector:
                 "mtu": iface_data.get("mtu"),
                 "is_up": iface_data.get("is_up"),
             }
+
+            nb_iface = self._get_or_create_interface(device, iface_name, iface_data)
+            if nb_iface is None:
+                self._record_missing_interface(device, iface_name, detected)
+                continue
 
             # Validate MAC address format before querying
             try:
@@ -975,6 +1006,9 @@ class NapalmCollector:
                 continue
 
             nb_iface = self._get_or_create_interface(device, iface_name, iface_data)
+            if nb_iface is None:
+                self._record_missing_interface(device, iface_name)
+                continue
 
             # --- LAG membership ---
             # Check the first logical interface's first family for "aenet"
@@ -1039,6 +1073,9 @@ class NapalmCollector:
                     continue
 
                 nb_li = self._get_or_create_interface(device, li_name, li_data)
+                if nb_li is None:
+                    self._record_missing_interface(device, li_name)
+                    continue
 
                 for fam_name, fam_data in families.items():
                     if fam_name not in ("inet", "inet6"):
@@ -1082,6 +1119,9 @@ class NapalmCollector:
 
         for iface_name, family_data in interfaces_ip.items():
             nb_li = self._get_or_create_interface(device, iface_name)
+            if nb_li is None:
+                self._record_missing_interface(device, iface_name)
+                continue
 
             # Resolve VRF from network instances
             ni_data = network_instances.get(iface_name, {})

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -43,6 +43,7 @@ from netbox_facts.helpers.napalm import (
     parse_network_instances,
 )
 from netbox_facts.helpers.netbox import (
+    claim_device_interface,
     create_module,
     detect_interface_type,
     duplicate_object_warning,
@@ -877,6 +878,24 @@ class NapalmCollector:
             object_repr=f"Interface {name}",
         )
 
+    def _record_missing_vrf(self, device, vrf_name, iface_name):
+        """Warn about a device VRF absent from NetBox and record a pending entry.
+
+        The entry payload (detected name plus 'VRF <name>' repr) is the
+        contract the applier's VRF handler consumes to create the VRF on
+        apply. The interface's IPs are skipped, so it is also excluded
+        from the stale sweep.
+        """
+        self._log_warning(f"VRF `{vrf_name}` not found in NetBox. Skipping IPs on `{iface_name}`.")
+        self._record_entry(
+            action=EntryActionChoices.ACTION_NEW,
+            collector_type=self._collector_type,
+            device=device,
+            detected_values={"name": vrf_name},
+            object_repr=f"VRF {vrf_name}",
+        )
+        self._skipped_ip_ifaces.add(iface_name)
+
     def interfaces(self, driver: NetworkDriver):
         """Collect interface data from a device using get_interfaces()."""
         self._seen_ips = set()
@@ -975,13 +994,7 @@ class NapalmCollector:
                 if created:
                     self._log_success(f"Created MAC address {get_absolute_url_markdown(netbox_mac, bold=True)}.")
 
-                # device_interface is one-to-one: release any other MAC row
-                # still holding this interface (hardware MAC change) before
-                # claiming it, or save() raises IntegrityError.
-                MACAddress.objects.filter(device_interface=nb_iface).exclude(pk=netbox_mac.pk).update(
-                    device_interface=None
-                )
-                netbox_mac.device_interface = nb_iface
+                claim_device_interface(netbox_mac, nb_iface)
                 netbox_mac.discovery_method = CollectionTypeChoices.TYPE_INTERFACES
                 netbox_mac.last_seen = self._now
                 netbox_mac.save()
@@ -1065,15 +1078,7 @@ class NapalmCollector:
                 try:
                     netbox_vrf = resolve_vrf(vrf_name)
                 except VRF.DoesNotExist:
-                    self._log_warning(f"VRF `{vrf_name}` not found in NetBox. Skipping IPs on `{li_name}`.")
-                    self._record_entry(
-                        action=EntryActionChoices.ACTION_NEW,
-                        collector_type=self._collector_type,
-                        device=device,
-                        detected_values={"name": vrf_name},
-                        object_repr=f"VRF {vrf_name}",
-                    )
-                    self._skipped_ip_ifaces.add(li_name)
+                    self._record_missing_vrf(device, vrf_name, li_name)
                     continue
                 except VRF.MultipleObjectsReturned:
                     self._log_warning(duplicate_object_warning("VRF", vrf_name) + f" Skipping IPs on `{li_name}`.")
@@ -1147,16 +1152,7 @@ class NapalmCollector:
                 self._skipped_ip_ifaces.add(iface_name)
                 continue
             if ni_data and "netbox_vrf" not in ni_data:
-                vrf_name = ni_data.get("name", "")
-                self._log_warning(f"VRF `{vrf_name}` not found in NetBox. Skipping IPs on `{iface_name}`.")
-                self._record_entry(
-                    action=EntryActionChoices.ACTION_NEW,
-                    collector_type=self._collector_type,
-                    device=device,
-                    detected_values={"name": vrf_name},
-                    object_repr=f"VRF {vrf_name}",
-                )
-                self._skipped_ip_ifaces.add(iface_name)
+                self._record_missing_vrf(device, ni_data.get("name", ""), iface_name)
                 continue
             netbox_vrf = ni_data.get("netbox_vrf")
 

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -942,6 +942,12 @@ class NapalmCollector:
                 if created:
                     self._log_success(f"Created MAC address {get_absolute_url_markdown(netbox_mac, bold=True)}.")
 
+                # device_interface is one-to-one: release any other MAC row
+                # still holding this interface (hardware MAC change) before
+                # claiming it, or save() raises IntegrityError.
+                MACAddress.objects.filter(device_interface=nb_iface).exclude(pk=netbox_mac.pk).update(
+                    device_interface=None
+                )
                 netbox_mac.device_interface = nb_iface
                 netbox_mac.discovery_method = CollectionTypeChoices.TYPE_INTERFACES
                 netbox_mac.last_seen = self._now

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -804,6 +804,24 @@ class NapalmCollector:
             if installed is not None:
                 modules_by_name[name] = installed
 
+    @staticmethod
+    def _pad_inet_destination(dest):
+        """Restore trailing zero octets Junos trims from inet destinations.
+
+        Junos abbreviates ifa-destination by dropping trailing zero octets
+        ("10/8", "172.16/16", "10.0.0/24"). Pad the network part back to
+        four octets so ip_network() can parse it with the real prefix
+        length. Anything that is not a shortened dotted-decimal form is
+        returned unchanged.
+        """
+        if "/" not in dest:
+            return dest
+        net_part, prefix_len = dest.split("/", 1)
+        octets = net_part.split(".")
+        if len(octets) >= 4 or not all(octet.isdigit() for octet in octets):
+            return dest
+        return ".".join(octets + ["0"] * (4 - len(octets))) + "/" + prefix_len
+
     def _get_or_create_interface(self, device, name, iface_data=None):
         """Look up an interface on a device, creating it if missing.
 
@@ -1031,10 +1049,8 @@ class NapalmCollector:
                         # Build CIDR
                         try:
                             if dest:
-                                # Handle incomplete inet destinations (3 octets)
-                                if fam_name == "inet" and dest.count(".") == 2:
-                                    net_part, prefix_len = dest.split("/")
-                                    net = ipaddress.ip_network(f"{net_part}.0/{prefix_len}")
+                                if fam_name == "inet":
+                                    net = ipaddress.ip_network(self._pad_inet_destination(dest), strict=False)
                                 else:
                                     net = ipaddress.ip_network(dest, strict=False)
                             else:

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -104,6 +104,7 @@ class NapalmCollector:
         self._detect_only: bool = getattr(plan, "detect_only", False)
         self._seen_ips: set = set()
         self._missing_ifaces: set = set()
+        self._skipped_ip_ifaces: set = set()
 
         # Get the NAPALM driver
         try:
@@ -880,6 +881,7 @@ class NapalmCollector:
         """Collect interface data from a device using get_interfaces()."""
         self._seen_ips = set()
         self._missing_ifaces = set()
+        self._skipped_ip_ifaces = set()
         # Always fetch all interfaces and filter client-side with the Python
         # regex.  Passing the regex pattern to the Junos RPC as interface_name
         # causes mismatches because Junos treats '.' as a literal dot while
@@ -989,10 +991,14 @@ class NapalmCollector:
         has_logical = any(iface_data.get("logical_interfaces") for iface_data in ifaces.values())
         if has_logical:
             self._interfaces_logical(device, ifaces)
+            ip_collection_complete = True
         else:
-            self._interfaces_ip_generic(device, driver)
+            ip_collection_complete = self._interfaces_ip_generic(device, driver)
 
-        self._detect_stale_ips(device)
+        if ip_collection_complete:
+            self._detect_stale_ips(device)
+        else:
+            self._log_warning("IP collection did not complete; skipping stale IP detection.")
         self._log_success("Interface collection completed")
 
     def _interfaces_logical(self, device, ifaces):
@@ -1067,9 +1073,11 @@ class NapalmCollector:
                         detected_values={"name": vrf_name},
                         object_repr=f"VRF {vrf_name}",
                     )
+                    self._skipped_ip_ifaces.add(li_name)
                     continue
                 except VRF.MultipleObjectsReturned:
                     self._log_warning(duplicate_object_warning("VRF", vrf_name) + f" Skipping IPs on `{li_name}`.")
+                    self._skipped_ip_ifaces.add(li_name)
                     continue
 
                 nb_li = self._get_or_create_interface(device, li_name, li_data)
@@ -1110,10 +1118,14 @@ class NapalmCollector:
                         self._record_ip_entry(device, nb_li, cidr, net, netbox_vrf)
 
     def _interfaces_ip_generic(self, device, driver):
-        """Collect IPs/VRFs using standard NAPALM get_interfaces_ip()."""
+        """Collect IPs/VRFs using standard NAPALM get_interfaces_ip().
+
+        Returns True when IP collection completed, False when the RPC
+        failed and the stale sweep must not run.
+        """
         interfaces_ip = self._napalm_rpc(driver.get_interfaces_ip, "interface IP data")
         if interfaces_ip is None:
-            return
+            return False
 
         network_instances = dict(self._get_network_instances(driver))
 
@@ -1139,11 +1151,21 @@ class NapalmCollector:
                         continue
 
                     self._record_ip_entry(device, nb_li, cidr, net, netbox_vrf)
+        return True
 
     def _detect_stale_ips(self, device):
-        """Detect auto-discovered IPs on a device that weren't seen in this run."""
+        """Detect auto-discovered IPs on a device that weren't seen in this run.
+
+        Only interfaces this run actually inspected are swept: names the
+        configured regex excludes, and interfaces whose IPs were skipped
+        (unresolvable VRF), keep their assignments.
+        """
         iface_ct = ContentType.objects.get_for_model(Interface)
-        device_iface_ids = device.vc_interfaces().values_list("pk", flat=True)
+        device_iface_ids = [
+            pk
+            for pk, name in device.vc_interfaces().values_list("pk", "name")
+            if self._interfaces_re.match(name) and name not in self._skipped_ip_ifaces
+        ]
         stale_ips = IPAddress.objects.filter(
             assigned_object_type=iface_ct,
             assigned_object_id__in=device_iface_ids,

--- a/netbox_facts/helpers/netbox.py
+++ b/netbox_facts/helpers/netbox.py
@@ -72,7 +72,12 @@ def resolve_napalm_network_instances(
     instances,
 ) -> Generator[tuple[str, dict[str, str | list[str]]], Any, Any]:
     """Parse network instances and resolve VRFs in NetBox.
-    Returns a generator of instance_name, data pairs where the netbox_vrf key is either missing, None or a VRF object.
+
+    Returns a generator of instance_name, data pairs. The netbox_vrf key is
+    None for non-L3VRF instances (global table), a VRF object when resolved,
+    and absent when the device VRF cannot be resolved in NetBox -- either
+    missing, or duplicated by name, in which case netbox_vrf_duplicate is
+    set to True so consumers can tell the two apart.
     """
     instances_by_name = {}
     for instance_name, data in instances.items():
@@ -83,6 +88,10 @@ def resolve_napalm_network_instances(
                 instances_by_name[instance_name] = data["netbox_vrf"]
             except VRF.DoesNotExist:  # pylint: disable=no-member
                 pass
+            except VRF.MultipleObjectsReturned:  # pylint: disable=no-member
+                # VRF names are not unique in NetBox; a duplicate cannot be
+                # resolved safely and must not abort the whole run.
+                data["netbox_vrf_duplicate"] = True
         else:
             data["netbox_vrf"] = None
         yield instance_name, data

--- a/netbox_facts/helpers/netbox.py
+++ b/netbox_facts/helpers/netbox.py
@@ -219,6 +219,20 @@ def get_or_create_mac(mac_addr):
     return netbox_mac, created
 
 
+def claim_device_interface(netbox_mac, nb_iface):
+    """Point a MACAddress row's device_interface at an interface.
+
+    device_interface is one-to-one: any other MACAddress row still holding
+    the interface (hardware MAC change) is released first with a single
+    targeted update, or saving the claim would raise IntegrityError.
+    Does not save; callers keep their own save flow.
+    """
+    from netbox_facts.models.mac import MACAddress
+
+    MACAddress.objects.filter(device_interface=nb_iface).exclude(pk=netbox_mac.pk).update(device_interface=None)
+    netbox_mac.device_interface = nb_iface
+
+
 def get_or_create_ip(address, vrf=None, **defaults):
     """Get or create an IPAddress, tagging with AUTO_D_TAG if created.
 

--- a/netbox_facts/tests/test_interfaces_regressions.py
+++ b/netbox_facts/tests/test_interfaces_regressions.py
@@ -147,3 +147,156 @@ class InterfaceMacReassignmentTest(InterfacesRegressionTestMixin, TestCase):
         self.assertIsNone(old_mac.device_interface)
         new_mac = MACAddress.objects.get(mac_address="AA:BB:CC:DD:EE:12")
         self.assertEqual(new_mac.device_interface, iface)
+
+
+class DetectOnlyInterfaceCreationTest(InterfacesRegressionTestMixin, TestCase):
+    """detect_only=True must never create Interface objects."""
+
+    def _detect_only_setup(self, name):
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name=f"DetectOnly-{name}",
+            detect_only=True,
+        )
+        device = self._create_device(name)
+        report = FactsReport.objects.create(collection_plan=plan)
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = report
+        return device, report, collector
+
+    def test_detect_only_generic_path_creates_no_interfaces(self):
+        """Regression test for issue #47: a detect-only run against a device
+        with no pre-created interfaces must leave Interface.objects untouched
+        and still record a pending entry for the missing interface."""
+        device, report, collector = self._detect_only_setup("detect-noiface-dev")
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "Ethernet1": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:41",
+            },
+        }
+        driver.get_interfaces_ip.return_value = {
+            "Ethernet1": {"ipv4": {"10.41.0.1": {"prefix_length": 24}}},
+        }
+        driver.get_network_instances.return_value = {}
+
+        collector.interfaces(driver)
+
+        self.assertEqual(Interface.objects.filter(device=device).count(), 0)
+        self.assertFalse(MACAddress.objects.filter(mac_address="AA:BB:CC:DD:EE:41").exists())
+        self.assertFalse(IPAddress.objects.filter(address="10.41.0.1/24").exists())
+        entries = report.entries.filter(object_repr="Interface Ethernet1")
+        self.assertEqual(entries.count(), 1)
+        self.assertEqual(entries[0].action, EntryActionChoices.ACTION_NEW)
+        self.assertEqual(entries[0].status, "pending")
+
+    def test_detect_only_logical_path_creates_no_interfaces(self):
+        """Regression test for issue #47: the Junos logical path must not
+        create the physical interface, and must record it exactly once."""
+        device, report, collector = self._detect_only_setup("detect-nolog-dev")
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "ge-0/0/1": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:42",
+                "logical_interfaces": {
+                    "ge-0/0/1.0": {
+                        "vrf": "",
+                        "families": {
+                            "inet": {
+                                "addresses": {
+                                    "10.42.0.0/24": {"local": "10.42.0.1", "preferred": True},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        collector.interfaces(driver)
+
+        self.assertEqual(Interface.objects.filter(device=device).count(), 0)
+        self.assertFalse(IPAddress.objects.filter(address="10.42.0.1/24").exists())
+        entries = report.entries.filter(object_repr="Interface ge-0/0/1")
+        self.assertEqual(entries.count(), 1)
+        self.assertEqual(entries[0].action, EntryActionChoices.ACTION_NEW)
+
+    def test_detect_only_missing_logical_unit_not_created(self):
+        """Regression test for issue #47: a missing logical unit under an
+        existing physical interface must be recorded, not created."""
+        device, report, collector = self._detect_only_setup("detect-nounit-dev")
+        Interface.objects.create(device=device, name="ge-0/0/2", type="1000base-t")
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "ge-0/0/2": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:43",
+                "logical_interfaces": {
+                    "ge-0/0/2.0": {
+                        "vrf": "",
+                        "families": {
+                            "inet": {
+                                "addresses": {
+                                    "10.43.0.0/24": {"local": "10.43.0.1", "preferred": True},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        collector.interfaces(driver)
+
+        self.assertEqual(Interface.objects.filter(device=device).count(), 1)
+        self.assertFalse(IPAddress.objects.filter(address="10.43.0.1/24").exists())
+        entries = report.entries.filter(object_repr="Interface ge-0/0/2.0")
+        self.assertEqual(entries.count(), 1)
+        self.assertEqual(entries[0].action, EntryActionChoices.ACTION_NEW)
+
+    def test_applier_creates_interface_from_pending_entry(self):
+        """Regression test for issue #47: the applier must create the
+        interface recorded by a detect-only run, even without a MAC."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name="DetectOnly-apply-iface",
+            detect_only=True,
+        )
+        device = self._create_device("detect-apply-iface-dev")
+        report = FactsReport.objects.create(collection_plan=plan)
+        entry = FactsReportEntry.objects.create(
+            report=report,
+            action=EntryActionChoices.ACTION_NEW,
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            device=device,
+            object_repr="Interface lo0",
+            detected_values={"interface": "lo0", "mac_address": ""},
+            current_values={},
+        )
+
+        applied, failed = apply_entries(report, [entry.pk])
+
+        self.assertEqual(applied, 1)
+        self.assertEqual(failed, 0)
+        self.assertTrue(Interface.objects.filter(device=device, name="lo0").exists())

--- a/netbox_facts/tests/test_interfaces_regressions.py
+++ b/netbox_facts/tests/test_interfaces_regressions.py
@@ -7,7 +7,10 @@ from django.test import TestCase
 from ipam.models.ip import IPAddress, Prefix
 from unittest.mock import MagicMock
 
-from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices
+from netbox_facts.helpers.applier import apply_entries
+from netbox_facts.models import FactsReport, FactsReportEntry
+from netbox_facts.models.mac import MACAddress
 from netbox_facts.tests.test_helpers import CollectorTestMixin
 
 
@@ -72,3 +75,75 @@ class JunosAbbreviatedDestinationTest(InterfacesRegressionTestMixin, TestCase):
         self.assertTrue(Prefix.objects.filter(prefix="10.0.0.0/8").exists())
         self.assertTrue(Prefix.objects.filter(prefix="172.16.0.0/16").exists())
         self.assertTrue(Prefix.objects.filter(prefix="10.0.1.0/24").exists())
+
+
+class InterfaceMacReassignmentTest(InterfacesRegressionTestMixin, TestCase):
+    """A changed hardware MAC must not trip the device_interface OneToOne."""
+
+    def test_collector_releases_old_mac_row(self):
+        """Regression test for issue #55: when an interface's MAC changes,
+        the collector must release the old MACAddress row instead of
+        raising IntegrityError and aborting the run."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name="Plan-mac-swap",
+        )
+        device = self._create_device("mac-swap-dev")
+        iface = Interface.objects.create(device=device, name="Ethernet1", type="1000base-t")
+        old_mac = MACAddress.objects.create(mac_address="AA:BB:CC:DD:EE:01", device_interface=iface)
+        collector = self._make_collector(plan)
+        collector._current_device = device
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "Ethernet1": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:02",
+            },
+        }
+        driver.get_interfaces_ip.return_value = {}
+        driver.get_network_instances.return_value = {}
+
+        collector.interfaces(driver)
+
+        old_mac.refresh_from_db()
+        self.assertIsNone(old_mac.device_interface)
+        new_mac = MACAddress.objects.get(mac_address="AA:BB:CC:DD:EE:02")
+        self.assertEqual(new_mac.device_interface, iface)
+
+    def test_applier_releases_old_mac_row(self):
+        """Regression test for issue #55: applying a MAC entry for an
+        interface already held by another MACAddress row must release the
+        old row instead of failing the entry."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name="Plan-mac-swap-apply",
+            detect_only=True,
+        )
+        device = self._create_device("mac-swap-apply-dev")
+        iface = Interface.objects.create(device=device, name="Ethernet1", type="1000base-t")
+        old_mac = MACAddress.objects.create(mac_address="AA:BB:CC:DD:EE:11", device_interface=iface)
+        report = FactsReport.objects.create(collection_plan=plan)
+        entry = FactsReportEntry.objects.create(
+            report=report,
+            action=EntryActionChoices.ACTION_NEW,
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            device=device,
+            object_repr="MACAddress AA:BB:CC:DD:EE:12",
+            detected_values={"interface": "Ethernet1", "mac_address": "AA:BB:CC:DD:EE:12"},
+            current_values={},
+        )
+
+        applied, failed = apply_entries(report, [entry.pk])
+
+        self.assertEqual(applied, 1)
+        self.assertEqual(failed, 0)
+        old_mac.refresh_from_db()
+        self.assertIsNone(old_mac.device_interface)
+        new_mac = MACAddress.objects.get(mac_address="AA:BB:CC:DD:EE:12")
+        self.assertEqual(new_mac.device_interface, iface)

--- a/netbox_facts/tests/test_interfaces_regressions.py
+++ b/netbox_facts/tests/test_interfaces_regressions.py
@@ -1,0 +1,74 @@
+"""Regression tests for the interfaces collector and its helpers."""
+
+import re
+
+from dcim.models.device_components import Interface
+from django.test import TestCase
+from ipam.models.ip import IPAddress, Prefix
+from unittest.mock import MagicMock
+
+from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.tests.test_helpers import CollectorTestMixin
+
+
+class InterfacesRegressionTestMixin(CollectorTestMixin):
+    """CollectorTestMixin with a real catch-all interface regex."""
+
+    def _make_collector(self, plan):
+        collector = super()._make_collector(plan)
+        collector._interfaces_re = re.compile(r".*")
+        return collector
+
+
+class JunosAbbreviatedDestinationTest(InterfacesRegressionTestMixin, TestCase):
+    """Junos trims trailing zero octets from inet destinations."""
+
+    def test_abbreviated_inet_destinations_keep_real_prefix_length(self):
+        """Regression test for issue #56: '10/8' and '172.16/16' destinations
+        must produce /8 and /16 addresses, never fall back to /32."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name="Plan-dest-pad",
+        )
+        device = self._create_device("dest-pad-dev")
+        Interface.objects.create(device=device, name="xe-0/0/0", type="other")
+        collector = self._make_collector(plan)
+        collector._current_device = device
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "xe-0/0/0": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 10000.0,
+                "mtu": 1500,
+                "mac_address": "",
+                "logical_interfaces": {
+                    "xe-0/0/0.0": {
+                        "vrf": "",
+                        "families": {
+                            "inet": {
+                                "addresses": {
+                                    "10/8": {"local": "10.0.0.1", "preferred": True},
+                                    "172.16/16": {"local": "172.16.5.1", "preferred": True},
+                                    "10.0.1/24": {"local": "10.0.1.5", "preferred": True},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        collector.interfaces(driver)
+
+        self.assertTrue(IPAddress.objects.filter(address="10.0.0.1/8").exists())
+        self.assertTrue(IPAddress.objects.filter(address="172.16.5.1/16").exists())
+        self.assertTrue(IPAddress.objects.filter(address="10.0.1.5/24").exists())
+        self.assertFalse(IPAddress.objects.filter(address="10.0.0.1/32").exists())
+        self.assertFalse(IPAddress.objects.filter(address="172.16.5.1/32").exists())
+        self.assertTrue(Prefix.objects.filter(prefix="10.0.0.0/8").exists())
+        self.assertTrue(Prefix.objects.filter(prefix="172.16.0.0/16").exists())
+        self.assertTrue(Prefix.objects.filter(prefix="10.0.1.0/24").exists())

--- a/netbox_facts/tests/test_interfaces_regressions.py
+++ b/netbox_facts/tests/test_interfaces_regressions.py
@@ -1,19 +1,18 @@
 """Regression tests for the interfaces collector and its helpers."""
 
 import re
+from unittest.mock import MagicMock
 
 from dcim.models.device_components import Interface
 from django.test import TestCase
 from ipam.models.ip import IPAddress, Prefix
 from ipam.models.vrfs import VRF
 from napalm.base.exceptions import ConnectionException
-from unittest.mock import MagicMock
-
-from netbox_facts.constants import AUTO_D_TAG
-from netbox_facts.helpers.netbox import resolve_napalm_network_instances
 
 from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices
+from netbox_facts.constants import AUTO_D_TAG
 from netbox_facts.helpers.applier import apply_entries
+from netbox_facts.helpers.netbox import resolve_napalm_network_instances
 from netbox_facts.models import FactsReport, FactsReportEntry
 from netbox_facts.models.mac import MACAddress
 from netbox_facts.tests.test_helpers import CollectorTestMixin

--- a/netbox_facts/tests/test_interfaces_regressions.py
+++ b/netbox_facts/tests/test_interfaces_regressions.py
@@ -5,7 +5,10 @@ import re
 from dcim.models.device_components import Interface
 from django.test import TestCase
 from ipam.models.ip import IPAddress, Prefix
+from napalm.base.exceptions import ConnectionException
 from unittest.mock import MagicMock
+
+from netbox_facts.constants import AUTO_D_TAG
 
 from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices
 from netbox_facts.helpers.applier import apply_entries
@@ -300,3 +303,86 @@ class DetectOnlyInterfaceCreationTest(InterfacesRegressionTestMixin, TestCase):
         self.assertEqual(applied, 1)
         self.assertEqual(failed, 0)
         self.assertTrue(Interface.objects.filter(device=device, name="lo0").exists())
+
+
+class StaleIpScopeTest(InterfacesRegressionTestMixin, TestCase):
+    """The stale-IP sweep must only cover what this run could have seen."""
+
+    def test_failed_ip_collection_skips_stale_sweep(self):
+        """Regression test for issue #49: when get_interfaces_ip fails, the
+        stale sweep must not run -- a transient RPC failure must not
+        unassign every previously discovered IP on the device."""
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name="Plan-stale-rpcfail",
+        )
+        device = self._create_device("stale-rpcfail-dev")
+        iface = Interface.objects.create(device=device, name="Ethernet5", type="1000base-t")
+        auto_ip = IPAddress.objects.create(address="10.51.0.1/24", assigned_object=iface)
+        auto_ip.tags.add(AUTO_D_TAG)
+
+        report = FactsReport.objects.create(collection_plan=plan)
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = report
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "Ethernet5": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:51",
+            },
+        }
+        driver.get_interfaces_ip.side_effect = ConnectionException("timeout")
+
+        collector.interfaces(driver)
+
+        auto_ip.refresh_from_db()
+        self.assertEqual(auto_ip.assigned_object, iface)
+        self.assertEqual(report.entries.filter(action=EntryActionChoices.ACTION_STALE).count(), 0)
+
+    def test_regex_excluded_interface_not_swept(self):
+        """Regression test for issue #49: an AUTO_D IP on an interface
+        excluded by the configured regex must not be flagged stale."""
+        import re as _re
+
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name="Plan-stale-regex",
+        )
+        device = self._create_device("stale-regex-dev")
+        mgmt = Interface.objects.create(device=device, name="Management1", type="1000base-t")
+        auto_ip = IPAddress.objects.create(address="10.52.0.1/24", assigned_object=mgmt)
+        auto_ip.tags.add(AUTO_D_TAG)
+
+        report = FactsReport.objects.create(collection_plan=plan)
+        collector = self._make_collector(plan)
+        collector._interfaces_re = _re.compile(r"ge-.*")
+        collector._current_device = device
+        collector._report = report
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            "ge-0/0/1": {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:52",
+            },
+        }
+        driver.get_interfaces_ip.return_value = {}
+        driver.get_network_instances.return_value = {}
+
+        collector.interfaces(driver)
+
+        auto_ip.refresh_from_db()
+        self.assertEqual(auto_ip.assigned_object, mgmt)
+        self.assertEqual(report.entries.filter(action=EntryActionChoices.ACTION_STALE).count(), 0)

--- a/netbox_facts/tests/test_interfaces_regressions.py
+++ b/netbox_facts/tests/test_interfaces_regressions.py
@@ -5,10 +5,12 @@ import re
 from dcim.models.device_components import Interface
 from django.test import TestCase
 from ipam.models.ip import IPAddress, Prefix
+from ipam.models.vrfs import VRF
 from napalm.base.exceptions import ConnectionException
 from unittest.mock import MagicMock
 
 from netbox_facts.constants import AUTO_D_TAG
+from netbox_facts.helpers.netbox import resolve_napalm_network_instances
 
 from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices
 from netbox_facts.helpers.applier import apply_entries
@@ -386,3 +388,96 @@ class StaleIpScopeTest(InterfacesRegressionTestMixin, TestCase):
         auto_ip.refresh_from_db()
         self.assertEqual(auto_ip.assigned_object, mgmt)
         self.assertEqual(report.entries.filter(action=EntryActionChoices.ACTION_STALE).count(), 0)
+
+
+class GenericPathVrfResolutionTest(InterfacesRegressionTestMixin, TestCase):
+    """Unresolvable device VRFs must not collapse to the global table."""
+
+    def _run_generic(self, name, instance_name, iface_name, ip_str):
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_INTERFACES,
+            name=f"Plan-{name}",
+        )
+        device = self._create_device(name)
+        Interface.objects.create(device=device, name=iface_name, type="1000base-t")
+        report = FactsReport.objects.create(collection_plan=plan)
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = report
+
+        driver = MagicMock()
+        driver.get_interfaces.return_value = {
+            iface_name: {
+                "is_up": True,
+                "is_enabled": True,
+                "description": "",
+                "last_flapped": -1.0,
+                "speed": 1000.0,
+                "mtu": 1500,
+                "mac_address": "AA:BB:CC:DD:EE:61",
+            },
+        }
+        driver.get_interfaces_ip.return_value = {
+            iface_name: {"ipv4": {ip_str: {"prefix_length": 24}}},
+        }
+        driver.get_network_instances.return_value = {
+            instance_name: {
+                "name": instance_name,
+                "type": "L3VRF",
+                "state": {"route_distinguisher": "65000:61"},
+                "interfaces": {"interface": {iface_name: {}}},
+            },
+        }
+
+        collector.interfaces(driver)
+        return device, report
+
+    def test_unknown_vrf_ips_skipped_not_booked_globally(self):
+        """Regression test for issue #57: IPs in a device VRF with no NetBox
+        counterpart must be skipped with a missing-VRF entry, not created in
+        the global table -- and must not steal an existing global IP."""
+        other_device = self._create_device("unknown-vrf-other-dev")
+        other_iface = Interface.objects.create(device=other_device, name="Ethernet1", type="1000base-t")
+        global_ip = IPAddress.objects.create(address="10.61.0.1/24", assigned_object=other_iface)
+        global_ip.tags.add(AUTO_D_TAG)
+
+        device, report = self._run_generic("unknown-vrf-dev", "CUST_A", "Ethernet7", "10.61.0.1")
+
+        global_ip.refresh_from_db()
+        self.assertEqual(global_ip.assigned_object, other_iface)
+        self.assertEqual(IPAddress.objects.filter(address="10.61.0.1/24").count(), 1)
+        vrf_entries = report.entries.filter(object_repr="VRF CUST_A")
+        self.assertEqual(vrf_entries.count(), 1)
+        self.assertEqual(vrf_entries[0].action, EntryActionChoices.ACTION_NEW)
+        self.assertEqual(vrf_entries[0].status, "pending")
+
+    def test_duplicate_vrf_names_do_not_abort_run(self):
+        """Regression test for issue #46: two NetBox VRFs sharing a name must
+        not raise MultipleObjectsReturned out of the collector; the affected
+        instance's IPs are skipped with a warning and no VRF entry."""
+        VRF.objects.create(name="DUPVRF", rd="65000:1")
+        VRF.objects.create(name="DUPVRF", rd="65000:2")
+
+        device, report = self._run_generic("dup-vrf-dev", "DUPVRF", "Ethernet9", "10.62.0.1")
+
+        self.assertFalse(IPAddress.objects.filter(address="10.62.0.1/24").exists())
+        self.assertEqual(report.entries.filter(object_repr="VRF DUPVRF").count(), 0)
+
+    def test_resolver_marks_duplicate_vrf(self):
+        """Regression test for issue #46: resolve_napalm_network_instances
+        must survive duplicate VRF names, leaving netbox_vrf unset and
+        flagging the instance as a duplicate."""
+        VRF.objects.create(name="DUPVRF2", rd="65000:3")
+        VRF.objects.create(name="DUPVRF2", rd="65000:4")
+        instances = {
+            "DUPVRF2": {
+                "instance_type": "L3VRF",
+                "route_distinguisher": "65000:3",
+                "interfaces": ["Ethernet1"],
+            },
+        }
+
+        result = dict(resolve_napalm_network_instances(instances))
+
+        self.assertNotIn("netbox_vrf", result["DUPVRF2"])
+        self.assertTrue(result["DUPVRF2"].get("netbox_vrf_duplicate"))


### PR DESCRIPTION
## Summary
- Restores the detect-only contract for the interfaces collector (no Interface rows created during detect-only runs) and defuses the destructive stale-IP sweep.
- Fixes MAC reassignment IntegrityErrors, short Junos destination parsing, and unknown/duplicate VRF handling in the generic IP path.

## Changes
- netbox_facts/helpers/collector.py: interface creation gated behind apply mode with pending entries recorded instead; stale-IP sweep skipped when IP collection fails and scoped to interfaces this run actually inspected; hardware MAC changes release the previous MACAddress row before claiming the interface; all shortened Junos inet destinations padded to four octets; unknown-VRF IPs skipped with a pending VRF entry instead of booked into the global table.
- netbox_facts/helpers/netbox.py: resolve_napalm_network_instances tolerates duplicate VRF names; shared claim_device_interface helper.
- netbox_facts/helpers/applier.py: _apply_interfaces_mac creates missing interfaces at apply time and shares the MAC-claim helper.
- netbox_facts/tests/test_interfaces_regressions.py: 12 regression tests, each red on the pre-fix code.
- CHANGELOG.md: entries under Unreleased / Fixed.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (153 tests across regression file, test_helpers.py, test_applier.py)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Fixes #46
Fixes #47
Fixes #49
Fixes #55
Fixes #56
Fixes #57
