### PR TITLE
fix(bgp): honor detect-only and fail entries on unresolved VRF or RIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           NETBOX_CONFIGURATION: netbox.configuration
         run: |
           cd /opt/netbox/netbox
-          python manage.py makemigrations --check --dry-run
+          python manage.py makemigrations netbox_facts --check --dry-run
 
       - name: Django system check
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           SECRET_KEY = "ci-only-secret-key-do-not-use-in-production-aaaaaaaaaaaaaaaaaaaa"
           API_TOKEN_PEPPERS = {1: (SECRET_KEY * 2)[:50]}
 
-          PLUGINS = ["netbox_facts"]
+          PLUGINS = ["netbox_facts", "netbox_routing"]
           PLUGINS_CONFIG = {"netbox_facts": {"top_level_menu": True}}
           EOF_CFG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Releases prior to 1.0.x use the legacy `## VERSION (DATE)` heading style.
   matrix pinned to the newest release of each supported minor. The
   README compatibility matrix now lists NetBox 4.5.x and 4.6.x.
 
+### Fixed
+
+- Detect-only BGP runs no longer create the device's local ASN in NetBox; the BGPRouter report entry is still recorded. (#48)
+- BGP collection and the applier BGP handlers no longer crash with an IntegrityError when NetBox has no RIR: the collector skips ASN creation with a warning, and applier entries that require the ASN fail with a clear message. (#54)
+- Applying an ARP/NDP, interfaces IP, or BGP peer entry whose detected VRF no longer resolves now fails the entry instead of silently writing the IP address into the global routing table. (#53)
+
 ## [0.1.1] - 2026-05-01
 
 ### Fixed

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -116,6 +116,28 @@ def _set_entry_object(entry, obj):
         entry.object_id = obj.pk
 
 
+def get_or_create_asn(as_number):
+    """Get or create an ipam ASN, returning None when it cannot be created.
+
+    ipam.ASN.rir is a non-nullable foreign key, so creating an ASN requires
+    at least one RIR in NetBox. When the ASN does not already exist and no
+    RIR is available, return None instead of letting the insert fail with an
+    IntegrityError; callers decide whether a missing ASN is a warning or an
+    error.
+    """
+    from ipam.models import ASN, RIR
+
+    as_number = int(as_number)
+    nb_asn = ASN.objects.filter(asn=as_number).first()
+    if nb_asn is not None:
+        return nb_asn
+    rir = RIR.objects.first()
+    if rir is None:
+        return None
+    nb_asn, _ = ASN.objects.get_or_create(asn=as_number, defaults={"rir": rir})
+    return nb_asn
+
+
 # --- Per-collector apply handlers ---
 
 
@@ -495,8 +517,6 @@ def _apply_vrf_entry(entry):
 
 def _apply_bgp_entry(entry, now):
     """Apply a BGP peer IP/ASN entry."""
-    from ipam.models import ASN, RIR
-
     if entry.object_repr.startswith("VRF "):
         return _apply_vrf_entry(entry)
     if entry.object_repr.startswith("BGPRouter "):
@@ -534,14 +554,8 @@ def _apply_bgp_entry(entry, now):
         description=f"BGP peer AS{as_number} discovered on {now}",
     )
 
-    if as_number is not None:
-        try:
-            ASN.objects.get_or_create(
-                asn=int(as_number),
-                defaults={"rir": RIR.objects.first()},
-            )
-        except (RIR.DoesNotExist, TypeError):
-            logger.warning("Could not create ASN %s for BGP entry %s (no RIR found)", as_number, entry.pk)
+    if as_number is not None and get_or_create_asn(as_number) is None:
+        logger.warning("No RIR exists in NetBox; cannot create ASN %s for BGP entry %s", as_number, entry.pk)
 
     _set_entry_object(entry, nb_ip)
 
@@ -594,7 +608,6 @@ def _apply_l2_circuits_entry(entry, now):
 
 def _apply_bgp_router_entry(entry):
     """Create a BGPRouter from a detect-only report entry."""
-    from ipam.models import ASN, RIR
     from netbox_routing.models import BGPRouter
 
     local_as = entry.detected_values.get("local_as")
@@ -604,10 +617,9 @@ def _apply_bgp_router_entry(entry):
     device = entry.device
     device_ct = ContentType.objects.get_for_model(device)
 
-    asn_obj, _ = ASN.objects.get_or_create(
-        asn=int(local_as),
-        defaults={"rir": RIR.objects.first()},
-    )
+    asn_obj = get_or_create_asn(local_as)
+    if asn_obj is None:
+        raise ValueError(f"No RIR exists in NetBox; cannot create local ASN {local_as} for the BGPRouter")
     router, created = BGPRouter.objects.get_or_create(
         assigned_object_type=device_ct,
         assigned_object_id=device.pk,
@@ -620,7 +632,6 @@ def _apply_bgp_router_entry(entry):
 
 def _apply_bgp_scope_entry(entry):
     """Create a BGPScope from a detect-only report entry."""
-    from ipam.models import ASN, RIR
     from netbox_routing.models import BGPRouter, BGPScope
 
     dv = entry.detected_values
@@ -629,10 +640,9 @@ def _apply_bgp_scope_entry(entry):
     device = entry.device
     device_ct = ContentType.objects.get_for_model(device)
 
-    asn_obj, _ = ASN.objects.get_or_create(
-        asn=int(local_as),
-        defaults={"rir": RIR.objects.first()},
-    )
+    asn_obj = get_or_create_asn(local_as)
+    if asn_obj is None:
+        raise ValueError(f"No RIR exists in NetBox; cannot create local ASN {local_as} for the BGPScope")
     router, _ = BGPRouter.objects.get_or_create(
         assigned_object_type=device_ct,
         assigned_object_id=device.pk,
@@ -654,7 +664,6 @@ def _apply_bgp_scope_entry(entry):
 
 def _apply_bgp_peer_routing_entry(entry):
     """Create a BGPPeer (netbox-routing) from a detect-only report entry."""
-    from ipam.models import ASN, RIR
     from netbox_routing.models import BGPPeer, BGPRouter, BGPScope
 
     dv = entry.detected_values
@@ -666,10 +675,9 @@ def _apply_bgp_peer_routing_entry(entry):
     device_ct = ContentType.objects.get_for_model(device)
 
     # Build chain: Router -> Scope
-    asn_obj, _ = ASN.objects.get_or_create(
-        asn=int(local_as),
-        defaults={"rir": RIR.objects.first()},
-    )
+    asn_obj = get_or_create_asn(local_as)
+    if asn_obj is None:
+        raise ValueError(f"No RIR exists in NetBox; cannot create local ASN {local_as} for the BGPPeer")
     router, _ = BGPRouter.objects.get_or_create(
         assigned_object_type=device_ct,
         assigned_object_id=device.pk,
@@ -693,10 +701,7 @@ def _apply_bgp_peer_routing_entry(entry):
 
     nb_remote_asn = None
     if as_number is not None:
-        nb_remote_asn, _ = ASN.objects.get_or_create(
-            asn=int(as_number),
-            defaults={"rir": RIR.objects.first()},
-        )
+        nb_remote_asn = get_or_create_asn(as_number)
 
     peer, created = BGPPeer.objects.get_or_create(
         scope=scope,

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -28,10 +28,13 @@ from netbox_facts.helpers.netbox import (
     get_or_create_mac,
     resolve_device_by_name,
     resolve_vrf,
+    resolve_vrf_or_fail,
 )
 from netbox_facts.models.mac import MACAddress
 
 logger = logging.getLogger("netbox_facts")
+
+NO_RIR_MESSAGE = "No RIR exists in NetBox; cannot create ASN {as_number}"
 
 
 def apply_entries(report, entry_pks):
@@ -176,13 +179,7 @@ def _apply_arp_entry(entry, now):
         if not ip_str:
             return
 
-        vrf = None
-        vrf_name = dv.get("vrf")
-        if vrf_name:
-            try:
-                vrf = resolve_vrf(vrf_name)
-            except VRF.DoesNotExist as exc:
-                raise ValueError(f"VRF {vrf_name} not found; not applying into the global table") from exc
+        vrf = resolve_vrf_or_fail(dv.get("vrf"))
 
         nb_ip, created = get_or_create_ip(
             ip_str,
@@ -380,12 +377,7 @@ def _apply_interfaces_ip(entry, dv, now):
     vrf_name = dv.get("vrf")
     prefix_str = dv.get("prefix")
 
-    vrf = None
-    if vrf_name:
-        try:
-            vrf = resolve_vrf(vrf_name)
-        except VRF.DoesNotExist as exc:
-            raise ValueError(f"VRF {vrf_name} not found; not applying into the global table") from exc
+    vrf = resolve_vrf_or_fail(vrf_name)
 
     nb_li = get_or_create_interface(entry.device, li_name)
 
@@ -534,12 +526,7 @@ def _apply_bgp_entry(entry, now):
     if not remote_address:
         return
 
-    nb_vrf = None
-    if vrf_name:
-        try:
-            nb_vrf = resolve_vrf(vrf_name)
-        except VRF.DoesNotExist as exc:
-            raise ValueError(f"VRF {vrf_name} not found; not applying into the global table") from exc
+    nb_vrf = resolve_vrf_or_fail(vrf_name)
 
     try:
         ip_obj = ipaddress.ip_address(remote_address)
@@ -555,7 +542,7 @@ def _apply_bgp_entry(entry, now):
     )
 
     if as_number is not None and get_or_create_asn(as_number) is None:
-        logger.warning("No RIR exists in NetBox; cannot create ASN %s for BGP entry %s", as_number, entry.pk)
+        logger.warning("%s (BGP entry %s)", NO_RIR_MESSAGE.format(as_number=as_number), entry.pk)
 
     _set_entry_object(entry, nb_ip)
 
@@ -606,52 +593,47 @@ def _apply_l2_circuits_entry(entry, now):
     _set_entry_object(entry, entry.device)
 
 
-def _apply_bgp_router_entry(entry):
-    """Create a BGPRouter from a detect-only report entry."""
+def _get_local_bgp_router(entry, local_as):
+    """Get or create the netbox-routing BGPRouter for an entry's device.
+
+    Resolves the device's local ASN first; ASN creation requires an RIR,
+    so an empty RIR table fails with a clear ValueError instead of an
+    IntegrityError. A router created here is tagged as auto-discovered.
+    """
     from netbox_routing.models import BGPRouter
-
-    local_as = entry.detected_values.get("local_as")
-    if local_as is None:
-        raise ValueError("BGPRouter entry has no local_as")
-
-    device = entry.device
-    device_ct = ContentType.objects.get_for_model(device)
 
     asn_obj = get_or_create_asn(local_as)
     if asn_obj is None:
-        raise ValueError(f"No RIR exists in NetBox; cannot create local ASN {local_as} for the BGPRouter")
+        raise ValueError(NO_RIR_MESSAGE.format(as_number=local_as))
+
+    device = entry.device
     router, created = BGPRouter.objects.get_or_create(
-        assigned_object_type=device_ct,
+        assigned_object_type=ContentType.objects.get_for_model(device),
         assigned_object_id=device.pk,
         asn=asn_obj,
     )
     if created:
         router.tags.add(AUTO_D_TAG)
+    return router
+
+
+def _apply_bgp_router_entry(entry):
+    """Create a BGPRouter from a detect-only report entry."""
+    local_as = entry.detected_values.get("local_as")
+    if local_as is None:
+        raise ValueError("BGPRouter entry has no local_as")
+
+    router = _get_local_bgp_router(entry, local_as)
     _set_entry_object(entry, router)
 
 
 def _apply_bgp_scope_entry(entry):
     """Create a BGPScope from a detect-only report entry."""
-    from netbox_routing.models import BGPRouter, BGPScope
+    from netbox_routing.models import BGPScope
 
     dv = entry.detected_values
-    local_as = dv.get("local_as")
-    vrf_name = dv.get("vrf")
-    device = entry.device
-    device_ct = ContentType.objects.get_for_model(device)
-
-    asn_obj = get_or_create_asn(local_as)
-    if asn_obj is None:
-        raise ValueError(f"No RIR exists in NetBox; cannot create local ASN {local_as} for the BGPScope")
-    router, _ = BGPRouter.objects.get_or_create(
-        assigned_object_type=device_ct,
-        assigned_object_id=device.pk,
-        asn=asn_obj,
-    )
-
-    nb_vrf = None
-    if vrf_name:
-        nb_vrf = resolve_vrf(vrf_name)
+    router = _get_local_bgp_router(entry, dv.get("local_as"))
+    nb_vrf = resolve_vrf_or_fail(dv.get("vrf"))
 
     scope, created = BGPScope.objects.get_or_create(
         router=router,
@@ -664,29 +646,15 @@ def _apply_bgp_scope_entry(entry):
 
 def _apply_bgp_peer_routing_entry(entry):
     """Create a BGPPeer (netbox-routing) from a detect-only report entry."""
-    from netbox_routing.models import BGPPeer, BGPRouter, BGPScope
+    from netbox_routing.models import BGPPeer, BGPScope
 
     dv = entry.detected_values
     remote_address = dv.get("remote_address", "")
     as_number = dv.get("remote_as")
-    local_as = dv.get("local_as")
-    vrf_name = dv.get("vrf")
-    device = entry.device
-    device_ct = ContentType.objects.get_for_model(device)
 
     # Build chain: Router -> Scope
-    asn_obj = get_or_create_asn(local_as)
-    if asn_obj is None:
-        raise ValueError(f"No RIR exists in NetBox; cannot create local ASN {local_as} for the BGPPeer")
-    router, _ = BGPRouter.objects.get_or_create(
-        assigned_object_type=device_ct,
-        assigned_object_id=device.pk,
-        asn=asn_obj,
-    )
-
-    nb_vrf = None
-    if vrf_name:
-        nb_vrf = resolve_vrf(vrf_name)
+    router = _get_local_bgp_router(entry, dv.get("local_as"))
+    nb_vrf = resolve_vrf_or_fail(dv.get("vrf"))
 
     scope, _ = BGPScope.objects.get_or_create(
         router=router,

--- a/netbox_facts/helpers/applier.py
+++ b/netbox_facts/helpers/applier.py
@@ -181,8 +181,8 @@ def _apply_arp_entry(entry, now):
         if vrf_name:
             try:
                 vrf = resolve_vrf(vrf_name)
-            except VRF.DoesNotExist:
-                logger.warning("VRF %s not found for ARP/NDP entry %s", vrf_name, entry.pk)
+            except VRF.DoesNotExist as exc:
+                raise ValueError(f"VRF {vrf_name} not found; not applying into the global table") from exc
 
         nb_ip, created = get_or_create_ip(
             ip_str,
@@ -384,8 +384,8 @@ def _apply_interfaces_ip(entry, dv, now):
     if vrf_name:
         try:
             vrf = resolve_vrf(vrf_name)
-        except VRF.DoesNotExist:
-            logger.warning("VRF %s not found for interfaces IP entry %s", vrf_name, entry.pk)
+        except VRF.DoesNotExist as exc:
+            raise ValueError(f"VRF {vrf_name} not found; not applying into the global table") from exc
 
     nb_li = get_or_create_interface(entry.device, li_name)
 
@@ -538,8 +538,8 @@ def _apply_bgp_entry(entry, now):
     if vrf_name:
         try:
             nb_vrf = resolve_vrf(vrf_name)
-        except VRF.DoesNotExist:
-            logger.warning("VRF %s not found for BGP entry %s", vrf_name, entry.pk)
+        except VRF.DoesNotExist as exc:
+            raise ValueError(f"VRF {vrf_name} not found; not applying into the global table") from exc
 
     try:
         ip_obj = ipaddress.ip_address(remote_address)

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -1639,15 +1639,18 @@ class NapalmCollector:
         device = self._current_device
         device_ct = ContentType.objects.get_for_model(device)
 
-        # Get-or-create local ASN
-        try:
-            local_asn, _ = ASN.objects.get_or_create(
-                asn=data["local_as"],
-                defaults={"rir": RIR.objects.first()},
-            )
-        except (RIR.DoesNotExist, TypeError):
-            self._log_warning(f"No RIR in NetBox. Cannot create local ASN {data['local_as']}.")
-            return
+        # Resolve the local ASN; only apply mode may create it
+        if self._should_apply():
+            try:
+                local_asn, _ = ASN.objects.get_or_create(
+                    asn=data["local_as"],
+                    defaults={"rir": RIR.objects.first()},
+                )
+            except (RIR.DoesNotExist, TypeError):
+                self._log_warning(f"No RIR in NetBox. Cannot create local ASN {data['local_as']}.")
+                return
+        else:
+            local_asn = ASN.objects.filter(asn=data["local_as"]).first()
 
         # BGPRouter
         if self._should_apply():

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -1497,7 +1497,7 @@ class NapalmCollector:
 
     def bgp(self, driver: NetworkDriver):
         """Collect BGP data from a device using get_bgp_neighbors_detail()."""
-        from netbox_facts.helpers.applier import get_or_create_asn
+        from netbox_facts.helpers.applier import NO_RIR_MESSAGE, get_or_create_asn
 
         bgp_data = self._napalm_rpc(driver.get_bgp_neighbors_detail, "BGP data")
         if bgp_data is None:
@@ -1566,7 +1566,7 @@ class NapalmCollector:
                         # Get or create the remote ASN (requires an RIR)
                         nb_asn = get_or_create_asn(as_number)
                         if nb_asn is None:
-                            self._log_warning(f"No RIR exists in NetBox. Cannot create ASN {as_number}.")
+                            self._log_warning(NO_RIR_MESSAGE.format(as_number=as_number))
 
                         try:
                             nb_ip, created = get_or_create_ip(
@@ -1629,7 +1629,7 @@ class NapalmCollector:
         from django.contrib.contenttypes.models import ContentType
         from ipam.models import ASN
 
-        from netbox_facts.helpers.applier import get_or_create_asn
+        from netbox_facts.helpers.applier import NO_RIR_MESSAGE, get_or_create_asn
 
         device = self._current_device
         device_ct = ContentType.objects.get_for_model(device)
@@ -1638,7 +1638,7 @@ class NapalmCollector:
         if self._should_apply():
             local_asn = get_or_create_asn(data["local_as"])
             if local_asn is None:
-                self._log_warning(f"No RIR in NetBox. Cannot create local ASN {data['local_as']}.")
+                self._log_warning(NO_RIR_MESSAGE.format(as_number=data["local_as"]))
                 return
         else:
             local_asn = ASN.objects.filter(asn=data["local_as"]).first()

--- a/netbox_facts/helpers/collector.py
+++ b/netbox_facts/helpers/collector.py
@@ -1497,7 +1497,7 @@ class NapalmCollector:
 
     def bgp(self, driver: NetworkDriver):
         """Collect BGP data from a device using get_bgp_neighbors_detail()."""
-        from ipam.models import ASN, RIR
+        from netbox_facts.helpers.applier import get_or_create_asn
 
         bgp_data = self._napalm_rpc(driver.get_bgp_neighbors_detail, "BGP data")
         if bgp_data is None:
@@ -1563,17 +1563,10 @@ class NapalmCollector:
                     )
 
                     if self._should_apply():
-                        # Try to get or create ASN (requires an RIR)
-                        nb_asn = None
-                        try:
-                            nb_asn, _ = ASN.objects.get_or_create(
-                                asn=int(as_number),
-                                defaults={"rir": RIR.objects.first()},
-                            )
-                        except (RIR.DoesNotExist, TypeError):
+                        # Get or create the remote ASN (requires an RIR)
+                        nb_asn = get_or_create_asn(as_number)
+                        if nb_asn is None:
                             self._log_warning(f"No RIR exists in NetBox. Cannot create ASN {as_number}.")
-                        except ASN.MultipleObjectsReturned:
-                            self._log_warning(duplicate_object_warning("ASN", as_number))
 
                         try:
                             nb_ip, created = get_or_create_ip(
@@ -1634,19 +1627,17 @@ class NapalmCollector:
             return
 
         from django.contrib.contenttypes.models import ContentType
-        from ipam.models import ASN, RIR
+        from ipam.models import ASN
+
+        from netbox_facts.helpers.applier import get_or_create_asn
 
         device = self._current_device
         device_ct = ContentType.objects.get_for_model(device)
 
         # Resolve the local ASN; only apply mode may create it
         if self._should_apply():
-            try:
-                local_asn, _ = ASN.objects.get_or_create(
-                    asn=data["local_as"],
-                    defaults={"rir": RIR.objects.first()},
-                )
-            except (RIR.DoesNotExist, TypeError):
+            local_asn = get_or_create_asn(data["local_as"])
+            if local_asn is None:
                 self._log_warning(f"No RIR in NetBox. Cannot create local ASN {data['local_as']}.")
                 return
         else:

--- a/netbox_facts/helpers/netbox.py
+++ b/netbox_facts/helpers/netbox.py
@@ -235,6 +235,21 @@ def resolve_vrf(name):
     return VRF.objects.get(name=name)
 
 
+def resolve_vrf_or_fail(name):
+    """Resolve a VRF by name, failing loudly when it does not exist.
+
+    Returns None for empty/global/default names, mirroring resolve_vrf.
+    Raises ValueError for a missing VRF so callers fail the operation
+    instead of silently falling back to the global routing table.
+    """
+    if not name:
+        return None
+    try:
+        return resolve_vrf(name)
+    except VRF.DoesNotExist as exc:
+        raise ValueError(f"VRF {name} not found; not applying into the global table") from exc
+
+
 def create_module(device, module_bay, module_type, serial):
     """Create a Module with adopt/disable-replication flags, tagged with AUTO_D_TAG."""
     from dcim.models.modules import Module

--- a/netbox_facts/tests/test_bgp_apply_regressions.py
+++ b/netbox_facts/tests/test_bgp_apply_regressions.py
@@ -3,14 +3,19 @@
 import unittest
 from unittest.mock import MagicMock
 
+from django.apps import apps
 from django.test import TestCase
 
 from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices, EntryStatusChoices
 from netbox_facts.helpers.applier import apply_entries
-from netbox_facts.helpers.collector import HAS_NETBOX_ROUTING
 from netbox_facts.models import FactsReport, FactsReportEntry
 from netbox_facts.tests.test_applier import ApplierTestMixin
 from netbox_facts.tests.test_helpers import CollectorTestMixin
+
+# The netbox-routing package can be importable while the plugin is not
+# enabled in the NetBox configuration; its models are only usable in the
+# latter case, so routing-dependent tests gate on the app being installed.
+NETBOX_ROUTING_ENABLED = apps.is_installed("netbox_routing")
 
 
 def _bgp_neighbors_payload(remote_address="10.0.0.1", local_as=65000, remote_as=65001):
@@ -30,7 +35,7 @@ def _bgp_neighbors_payload(remote_address="10.0.0.1", local_as=65000, remote_as=
     }
 
 
-@unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+@unittest.skipUnless(NETBOX_ROUTING_ENABLED, "netbox-routing plugin not enabled")
 class BGPRoutingDetectOnlyRegressionTest(CollectorTestMixin, TestCase):
     """Detect-only BGP runs must not write to NetBox (issue #48)."""
 
@@ -133,7 +138,7 @@ class ApplierNoRIRRegressionTest(ApplierTestMixin, TestCase):
         self.assertTrue(IPAddress.objects.filter(address="10.54.1.1/32").exists())
         self.assertFalse(ASN.objects.exists())
 
-    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    @unittest.skipUnless(NETBOX_ROUTING_ENABLED, "netbox-routing plugin not enabled")
     def test_bgp_router_entry_fails_with_clear_message_when_no_rir(self):
         """A BGPRouter entry with zero RIRs must fail with a clear message (issue #54)."""
         entry = self._make_entry(self.report, f"BGPRouter {self.device}", {"local_as": 65000})
@@ -145,7 +150,7 @@ class ApplierNoRIRRegressionTest(ApplierTestMixin, TestCase):
         self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
         self.assertIn("No RIR", entry.error_message)
 
-    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    @unittest.skipUnless(NETBOX_ROUTING_ENABLED, "netbox-routing plugin not enabled")
     def test_bgp_scope_entry_fails_with_clear_message_when_no_rir(self):
         """A BGPScope entry with zero RIRs must fail with a clear message (issue #54)."""
         entry = self._make_entry(
@@ -161,7 +166,7 @@ class ApplierNoRIRRegressionTest(ApplierTestMixin, TestCase):
         self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
         self.assertIn("No RIR", entry.error_message)
 
-    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    @unittest.skipUnless(NETBOX_ROUTING_ENABLED, "netbox-routing plugin not enabled")
     def test_bgp_peer_routing_entry_fails_with_clear_message_when_no_rir(self):
         """A BGPPeer routing entry with zero RIRs must fail with a clear message (issue #54)."""
         entry = self._make_entry(
@@ -247,7 +252,7 @@ class ApplierVRFResolutionRegressionTest(ApplierTestMixin, TestCase):
         )
         self._assert_failed_no_ip(entry, "10.53.2.1/32")
 
-    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    @unittest.skipUnless(NETBOX_ROUTING_ENABLED, "netbox-routing plugin not enabled")
     def test_bgp_scope_entry_with_unresolvable_vrf_fails_with_clear_message(self):
         """A BGPScope entry naming a missing VRF must fail with the canonical message (issue #53)."""
         entry = self._make_entry(

--- a/netbox_facts/tests/test_bgp_apply_regressions.py
+++ b/netbox_facts/tests/test_bgp_apply_regressions.py
@@ -176,3 +176,91 @@ class ApplierNoRIRRegressionTest(ApplierTestMixin, TestCase):
         entry.refresh_from_db()
         self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
         self.assertIn("No RIR", entry.error_message)
+
+
+class ApplierVRFResolutionRegressionTest(ApplierTestMixin, TestCase):
+    """A detected VRF that no longer resolves must fail the entry (issue #53)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        from ipam.models import RIR
+
+        RIR.objects.create(name="VRF-Test-RIR", slug="vrf-test-rir")
+
+    def setUp(self):
+        self.report = FactsReport.objects.create(collection_plan=self.plan)
+
+    def _make_entry(self, collector_type, object_repr, detected_values):
+        return FactsReportEntry.objects.create(
+            report=self.report,
+            action=EntryActionChoices.ACTION_NEW,
+            collector_type=collector_type,
+            device=self.device,
+            object_repr=object_repr,
+            detected_values=detected_values,
+        )
+
+    def _assert_failed_no_ip(self, entry, address):
+        from ipam.models.ip import IPAddress
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 0)
+        self.assertEqual(failed, 1)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
+        self.assertIn("VRF GONE_VRF not found", entry.error_message)
+        self.assertFalse(IPAddress.objects.filter(address=address).exists())
+
+    def test_arp_entry_with_unresolvable_vrf_fails(self):
+        """An ARP IP entry naming a missing VRF must fail, not go global (issue #53)."""
+        entry = self._make_entry(
+            CollectionTypeChoices.TYPE_ARP,
+            "IPAddress 10.53.0.1/32",
+            {"ip": "10.53.0.1/32", "mac": "AA:BB:CC:DD:EE:53", "interface": "", "vrf": "GONE_VRF"},
+        )
+        self._assert_failed_no_ip(entry, "10.53.0.1/32")
+
+    def test_interfaces_ip_entry_with_unresolvable_vrf_fails(self):
+        """An interfaces IP entry naming a missing VRF must fail, not go global (issue #53)."""
+        from ipam.models.ip import Prefix
+
+        entry = self._make_entry(
+            CollectionTypeChoices.TYPE_INTERFACES,
+            "IPAddress 10.53.1.5/24 on ge-0/0/0.0",
+            {
+                "ip_address": "10.53.1.5/24",
+                "logical_interface": "ge-0/0/0.0",
+                "vrf": "GONE_VRF",
+                "prefix": "10.53.1.0/24",
+            },
+        )
+        self._assert_failed_no_ip(entry, "10.53.1.5/24")
+        self.assertFalse(Prefix.objects.filter(prefix="10.53.1.0/24").exists())
+
+    def test_bgp_entry_with_unresolvable_vrf_fails(self):
+        """A BGP peer entry naming a missing VRF must fail, not go global (issue #53)."""
+        entry = self._make_entry(
+            CollectionTypeChoices.TYPE_BGP,
+            "BGP peer 10.53.2.1 AS65001",
+            {"remote_address": "10.53.2.1", "remote_as": 65001, "vrf": "GONE_VRF"},
+        )
+        self._assert_failed_no_ip(entry, "10.53.2.1/32")
+
+    def test_arp_entry_without_vrf_still_applies_globally(self):
+        """An ARP IP entry with no VRF must keep applying into the global table."""
+        from ipam.models.ip import IPAddress
+
+        entry = self._make_entry(
+            CollectionTypeChoices.TYPE_ARP,
+            "IPAddress 10.53.3.1/32",
+            {"ip": "10.53.3.1/32", "mac": "", "interface": "", "vrf": None},
+        )
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 1)
+        self.assertEqual(failed, 0)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, EntryStatusChoices.STATUS_APPLIED)
+        nb_ip = IPAddress.objects.get(address="10.53.3.1/32")
+        self.assertIsNone(nb_ip.vrf)

--- a/netbox_facts/tests/test_bgp_apply_regressions.py
+++ b/netbox_facts/tests/test_bgp_apply_regressions.py
@@ -1,0 +1,64 @@
+"""Regression tests for BGP collector/applier apply-semantics bugs."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.helpers.collector import HAS_NETBOX_ROUTING
+from netbox_facts.models import FactsReport, FactsReportEntry
+from netbox_facts.tests.test_helpers import CollectorTestMixin
+
+
+def _bgp_neighbors_payload(remote_address="10.0.0.1", local_as=65000, remote_as=65001):
+    """Build a minimal get_bgp_neighbors_detail payload with one global peer."""
+    return {
+        "global": {
+            str(remote_as): [
+                {
+                    "up": True,
+                    "local_as": local_as,
+                    "remote_as": remote_as,
+                    "remote_address": remote_address,
+                    "local_address": "10.0.0.2",
+                }
+            ]
+        }
+    }
+
+
+@unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+class BGPRoutingDetectOnlyRegressionTest(CollectorTestMixin, TestCase):
+    """Detect-only BGP runs must not write to NetBox (issue #48)."""
+
+    def test_detect_only_does_not_create_local_asn(self):
+        """A detect-only bgp() run must not create the local ASN (issue #48)."""
+        from ipam.models import ASN, RIR
+        from netbox_routing.models import BGPRouter
+
+        RIR.objects.create(name="Detect-RIR", slug="detect-rir")
+
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_BGP,
+            name="Plan-bgp-detect-only",
+            detect_only=True,
+        )
+        device = self._create_device("bgp-detect-dev")
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._report = FactsReport.objects.create(collection_plan=plan)
+
+        driver = MagicMock()
+        driver.get_bgp_neighbors_detail.return_value = _bgp_neighbors_payload()
+
+        collector.bgp(driver)
+
+        self.assertFalse(ASN.objects.exists())
+        self.assertFalse(BGPRouter.objects.exists())
+        self.assertTrue(
+            FactsReportEntry.objects.filter(
+                report=collector._report,
+                object_repr__startswith="BGPRouter",
+            ).exists()
+        )

--- a/netbox_facts/tests/test_bgp_apply_regressions.py
+++ b/netbox_facts/tests/test_bgp_apply_regressions.py
@@ -5,9 +5,11 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from netbox_facts.choices import CollectionTypeChoices
+from netbox_facts.choices import CollectionTypeChoices, EntryActionChoices, EntryStatusChoices
+from netbox_facts.helpers.applier import apply_entries
 from netbox_facts.helpers.collector import HAS_NETBOX_ROUTING
 from netbox_facts.models import FactsReport, FactsReportEntry
+from netbox_facts.tests.test_applier import ApplierTestMixin
 from netbox_facts.tests.test_helpers import CollectorTestMixin
 
 
@@ -62,3 +64,115 @@ class BGPRoutingDetectOnlyRegressionTest(CollectorTestMixin, TestCase):
                 object_repr__startswith="BGPRouter",
             ).exists()
         )
+
+
+class BGPCollectorNoRIRRegressionTest(CollectorTestMixin, TestCase):
+    """bgp() must survive a database with zero RIRs (issue #54)."""
+
+    def test_bgp_completes_with_zero_rirs(self):
+        """With no RIR, bgp() must warn and finish instead of raising (issue #54)."""
+        from ipam.models import ASN, RIR
+        from ipam.models.ip import IPAddress
+
+        self.assertFalse(RIR.objects.exists())
+
+        plan = self._create_plan(
+            collector_type=CollectionTypeChoices.TYPE_BGP,
+            name="Plan-bgp-no-rir",
+            detect_only=False,
+        )
+        device = self._create_device("bgp-no-rir-dev")
+        collector = self._make_collector(plan)
+        collector._current_device = device
+        collector._log_warning = MagicMock()
+
+        driver = MagicMock()
+        driver.get_bgp_neighbors_detail.return_value = _bgp_neighbors_payload(remote_address="10.54.0.1")
+
+        collector.bgp(driver)
+
+        self.assertTrue(IPAddress.objects.filter(address="10.54.0.1/32").exists())
+        self.assertFalse(ASN.objects.exists())
+        warning_text = " ".join(str(call.args[0]) for call in collector._log_warning.call_args_list)
+        self.assertIn("No RIR", warning_text)
+
+
+class ApplierNoRIRRegressionTest(ApplierTestMixin, TestCase):
+    """Applier BGP handlers must not raise IntegrityError with zero RIRs (issue #54)."""
+
+    def _make_entry(self, report, object_repr, detected_values):
+        return FactsReportEntry.objects.create(
+            report=report,
+            action=EntryActionChoices.ACTION_NEW,
+            collector_type=CollectionTypeChoices.TYPE_BGP,
+            device=self.device,
+            object_repr=object_repr,
+            detected_values=detected_values,
+        )
+
+    def setUp(self):
+        from ipam.models import RIR
+
+        self.assertFalse(RIR.objects.exists())
+        self.report = FactsReport.objects.create(collection_plan=self.plan)
+
+    def test_bgp_peer_entry_applies_without_asn_when_no_rir(self):
+        """A plain BGP peer entry must apply with zero RIRs, skipping the ASN (issue #54)."""
+        from ipam.models import ASN
+        from ipam.models.ip import IPAddress
+
+        entry = self._make_entry(
+            self.report,
+            "BGP peer 10.54.1.1 AS65001",
+            {"remote_address": "10.54.1.1", "remote_as": 65001, "vrf": None},
+        )
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 1)
+        self.assertEqual(failed, 0)
+        self.assertTrue(IPAddress.objects.filter(address="10.54.1.1/32").exists())
+        self.assertFalse(ASN.objects.exists())
+
+    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    def test_bgp_router_entry_fails_with_clear_message_when_no_rir(self):
+        """A BGPRouter entry with zero RIRs must fail with a clear message (issue #54)."""
+        entry = self._make_entry(self.report, f"BGPRouter {self.device}", {"local_as": 65000})
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 0)
+        self.assertEqual(failed, 1)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
+        self.assertIn("No RIR", entry.error_message)
+
+    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    def test_bgp_scope_entry_fails_with_clear_message_when_no_rir(self):
+        """A BGPScope entry with zero RIRs must fail with a clear message (issue #54)."""
+        entry = self._make_entry(
+            self.report,
+            f"BGPScope {self.device} global",
+            {"local_as": 65000, "vrf": None},
+        )
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 0)
+        self.assertEqual(failed, 1)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
+        self.assertIn("No RIR", entry.error_message)
+
+    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    def test_bgp_peer_routing_entry_fails_with_clear_message_when_no_rir(self):
+        """A BGPPeer routing entry with zero RIRs must fail with a clear message (issue #54)."""
+        entry = self._make_entry(
+            self.report,
+            "BGPPeer 10.54.2.1 AS65001",
+            {"remote_address": "10.54.2.1", "remote_as": 65001, "local_as": 65000, "vrf": None},
+        )
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 0)
+        self.assertEqual(failed, 1)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
+        self.assertIn("No RIR", entry.error_message)

--- a/netbox_facts/tests/test_bgp_apply_regressions.py
+++ b/netbox_facts/tests/test_bgp_apply_regressions.py
@@ -247,6 +247,22 @@ class ApplierVRFResolutionRegressionTest(ApplierTestMixin, TestCase):
         )
         self._assert_failed_no_ip(entry, "10.53.2.1/32")
 
+    @unittest.skipUnless(HAS_NETBOX_ROUTING, "netbox-routing not installed")
+    def test_bgp_scope_entry_with_unresolvable_vrf_fails_with_clear_message(self):
+        """A BGPScope entry naming a missing VRF must fail with the canonical message (issue #53)."""
+        entry = self._make_entry(
+            CollectionTypeChoices.TYPE_BGP,
+            f"BGPScope {self.device} GONE_VRF",
+            {"local_as": 65000, "vrf": "GONE_VRF"},
+        )
+
+        applied, failed = apply_entries(self.report, [entry.pk])
+        self.assertEqual(applied, 0)
+        self.assertEqual(failed, 1)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, EntryStatusChoices.STATUS_FAILED)
+        self.assertIn("VRF GONE_VRF not found", entry.error_message)
+
     def test_arp_entry_without_vrf_still_applies_globally(self):
         """An ARP IP entry with no VRF must keep applying into the global table."""
         from ipam.models.ip import IPAddress


### PR DESCRIPTION
## Summary
- Restores the detect-only contract for BGP runs (no ASN objects created during detect-only).
- Removes the zero-RIR IntegrityError crash and stops the applier from silently writing IPs into the global routing table when a VRF no longer resolves.

## Changes
- netbox_facts/helpers/collector.py: detect-only runs look up the local ASN instead of creating it; ASN creation goes through a shared RIR-aware helper with dead except clauses removed; No-RIR messages unified.
- netbox_facts/helpers/applier.py: shared get_or_create_asn helper; VRF resolution failures fail the entry with a clear message via resolve_vrf_or_fail instead of downgrading to the global table; BGP router/scope/peer handlers share one local-router helper.
- netbox_facts/helpers/netbox.py: resolve_vrf_or_fail helper.
- netbox_facts/tests/test_bgp_apply_regressions.py: 10 regression tests, each red on the pre-fix code.
- CHANGELOG.md: entries under Unreleased / Fixed.

Behavior note: BGPRouter objects auto-created through the scope/peer apply
paths are now tagged Automatically Discovered on create (previously only the
router handler tagged them) -- a consistency side effect of the shared
helper.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (151 tests across regression file, test_applier.py, test_helpers.py)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Fixes #48
Fixes #53
Fixes #54
